### PR TITLE
Node subcommand improvements

### DIFF
--- a/.hound.ruby.yml
+++ b/.hound.ruby.yml
@@ -1,9 +1,11 @@
 inherit_from: .hound.suse.yml
 
 AllCops:
-  RunRailsCops: true
   DisplayStyleGuide: true
   DisplayCopNames: true
+
+Rails:
+  Enabled: true
 
 Style/RedundantReturn:
   Exclude:
@@ -19,6 +21,9 @@ Style/AlignHash:
 
 Style/DotPosition:
   EnforcedStyle: leading
+
+Style/CaseIndentation:
+  IndentWhenRelativeTo: end
 
 Style/Documentation:
   Enabled: false

--- a/lib/crowbar/client/app/node.rb
+++ b/lib/crowbar/client/app/node.rb
@@ -100,6 +100,10 @@ module Crowbar
           With --filter <filter> option you can limit the result of
           printed out elements. You can use any substring that is part
           of the found elements.
+
+          With --no-meta switch you can disable the additional information
+          and just get a list of names and aliases for further scripting
+          where you don't care about the other columns.
         LONGDESC
 
         method_option :format,
@@ -131,6 +135,12 @@ module Crowbar
           default: nil,
           banner: "<filter>",
           desc: "Filter by criteria, display only data that contains filter"
+
+        method_option :meta,
+          type: :boolean,
+          default: true,
+          aliases: [],
+          desc: "Show or hide the additional meta info like group and status"
 
         def list
           Command::Node::List.new(

--- a/lib/crowbar/client/app/node.rb
+++ b/lib/crowbar/client/app/node.rb
@@ -447,6 +447,27 @@ module Crowbar
           catch_errors(e)
         end
 
+        desc "group NAME_OR_ALIAS GROUP",
+          "Assign another group to a node"
+
+        long_desc <<-LONGDESC
+          `group NAME_OR_ALIAS GROUP` will try to assign the specified
+          node to a different group. If you want to guess a group
+          automatically you can provide the group "automatic", then you
+          will get the new name as a response.
+        LONGDESC
+
+        def group(name, value)
+          Command::Node::Group.new(
+            *command_params(
+              name: name,
+              value: value
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
         desc "transition NAME_OR_ALIAS STATE",
           "Transition a node to a specific state"
 

--- a/lib/crowbar/client/app/node.rb
+++ b/lib/crowbar/client/app/node.rb
@@ -100,12 +100,6 @@ module Crowbar
           With --filter <filter> option you can limit the result of
           printed out elements. You can use any substring that is part
           of the found elements.
-
-          With --no-aliases switch you can disable the output of the node
-          aliases, per default the listing will display them.
-
-          With --no-names switch you can disable the output of the node
-          names, per default the listing will display them.
         LONGDESC
 
         method_option :format,
@@ -137,18 +131,6 @@ module Crowbar
           default: nil,
           banner: "<filter>",
           desc: "Filter by criteria, display only data that contains filter"
-
-        method_option :aliases,
-          type: :boolean,
-          default: true,
-          aliases: [],
-          desc: "Show or hide the aliases for the available nodes within listing"
-
-        method_option :names,
-          type: :boolean,
-          default: true,
-          aliases: [],
-          desc: "Show or hide the names for the available nodes within listing"
 
         def list
           Command::Node::List.new(

--- a/lib/crowbar/client/command/node.rb
+++ b/lib/crowbar/client/command/node.rb
@@ -24,6 +24,9 @@ module Crowbar
         autoload :Delete,
           File.expand_path("../node/delete", __FILE__)
 
+        autoload :Group,
+          File.expand_path("../node/group", __FILE__)
+
         autoload :Hardware,
           File.expand_path("../node/hardware", __FILE__)
 

--- a/lib/crowbar/client/command/node/group.rb
+++ b/lib/crowbar/client/command/node/group.rb
@@ -1,0 +1,44 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Node
+        class Group < Base
+          def request
+            @request ||= Request::Node::Group.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully updated group to #{request.parsed_response["group"]}"
+              when 404
+                err "Node does not exist"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/node/list.rb
+++ b/lib/crowbar/client/command/node/list.rb
@@ -55,30 +55,23 @@ module Crowbar
           protected
 
           def headings
-            [].tap do |values|
-              values.push("Name") if options["names"]
-              values.push("Alias") if options["aliases"]
-            end
+            [
+              "Name",
+              "Alias"
+            ]
           end
 
           def content_from(request)
             [].tap do |row|
               request.parsed_response["nodes"].each do |child|
-                values = {}
-                values[:name] = child["name"] if options["names"]
-                values[:alias] = child["alias"] if options["aliases"]
-
                 row.push(
-                  values
+                  child.slice(
+                    "name",
+                    "alias"
+                  )
                 )
               end
             end
-          end
-
-          def checks
-            msg = "Please provide only names or aliases switch"
-            raise BadOptionsError,
-              msg unless options["names"] || options["aliases"]
           end
         end
       end

--- a/lib/crowbar/client/command/node/list.rb
+++ b/lib/crowbar/client/command/node/list.rb
@@ -55,21 +55,39 @@ module Crowbar
           protected
 
           def headings
-            [
-              "Name",
-              "Alias"
-            ]
+            if options["meta"]
+              [
+                "Name",
+                "Alias",
+                "Group",
+                "Status"
+              ]
+            else
+              [
+                "Name"
+              ]
+            end
           end
 
           def content_from(request)
             [].tap do |row|
               request.parsed_response["nodes"].each do |child|
-                row.push(
-                  child.slice(
-                    "name",
-                    "alias"
+                if options["meta"]
+                  row.push(
+                    child.slice(
+                      "name",
+                      "alias",
+                      "group",
+                      "status"
+                    )
                   )
-                )
+                else
+                  row.push(
+                    child.slice(
+                      "name"
+                    )
+                  )
+                end
               end
             end
           end

--- a/lib/crowbar/client/command/node/list.rb
+++ b/lib/crowbar/client/command/node/list.rb
@@ -70,7 +70,7 @@ module Crowbar
           end
 
           def content_from(request)
-            [].tap do |row|
+            result = [].tap do |row|
               request.parsed_response["nodes"].each do |child|
                 if options["meta"]
                   row.push(
@@ -89,6 +89,16 @@ module Crowbar
                   )
                 end
               end
+            end
+
+            result.sort do |x, y|
+              [
+                x["name"],
+                x["alias"]
+              ] <=> [
+                y["name"],
+                y["alias"]
+              ]
             end
           end
         end

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -109,15 +109,15 @@ module Crowbar
       def merge
         result = {}.tap do |overwrite|
           defaults.keys.each do |key|
-            case
+            overwrite[key] = case
             when options[key] != defaults[key]
-              overwrite[key] = options[key]
+              options[key]
             when config[key].present?
-              overwrite[key] = config[key]
+              config[key]
             when options[key].present?
-              overwrite[key] = options[key]
+              options[key]
             else
-              overwrite[key] = defaults[key]
+              defaults[key]
             end
           end
         end

--- a/lib/crowbar/client/mixin/barclamp.rb
+++ b/lib/crowbar/client/mixin/barclamp.rb
@@ -29,10 +29,7 @@ module Crowbar
           end
 
           def available_barclamps
-            @available_barclamps ||= Request::Barclamp::List
-              .new
-              .process
-              .keys
+            @available_barclamps ||= Request::Barclamp::List.new.process.keys
           end
         end
       end

--- a/lib/crowbar/client/request/node.rb
+++ b/lib/crowbar/client/request/node.rb
@@ -24,6 +24,9 @@ module Crowbar
         autoload :Delete,
           File.expand_path("../node/delete", __FILE__)
 
+        autoload :Group,
+          File.expand_path("../node/group", __FILE__)
+
         autoload :List,
           File.expand_path("../node/list", __FILE__)
 

--- a/lib/crowbar/client/request/node/group.rb
+++ b/lib/crowbar/client/request/node/group.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Node
+        class Group < Base
+          def method
+            :post
+          end
+
+          def url
+            [
+              "nodes",
+              "groups",
+              "1.0",
+              attrs.name,
+              attrs.value
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/command/node/group_spec.rb
+++ b/spec/crowbar/client/command/node/group_spec.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Node::Group" do
+  include_context "command_context"
+
+  subject do
+    ::Crowbar::Client::Command::Node::Group.new(
+      stdin,
+      stdout,
+      stderr
+    )
+  end
+
+  it "should always return a request class" do
+    expect(subject.request).to(
+      be_a(
+        ::Crowbar::Client::Request::Node::Group
+      )
+    )
+  end
+
+  pending
+end

--- a/spec/crowbar/client/command/proposal/create_spec.rb
+++ b/spec/crowbar/client/command/proposal/create_spec.rb
@@ -28,14 +28,10 @@ describe "Crowbar::Client::Command::Proposal::Create" do
   end
 
   it "should always return a request class" do
-    subject.args.merge!(
-      barclamp: "testing"
-    )
+    subject.args[:barclamp] = "testing"
 
-    subject.options.merge!(
-      merge: true,
-      data: "{}"
-    )
+    subject.options[:merge] = true
+    subject.options[:data] = "{}"
 
     stub_request(:get, "http://crowbar/crowbar/testing/1.0/proposals/template")
       .with(

--- a/spec/crowbar/client/command/proposal/edit_spec.rb
+++ b/spec/crowbar/client/command/proposal/edit_spec.rb
@@ -28,15 +28,11 @@ describe "Crowbar::Client::Command::Proposal::Edit" do
   end
 
   it "should always return a request class" do
-    subject.args.merge!(
-      barclamp: "testing",
-      proposal: "default"
-    )
+    subject.args[:barclamp] = "testing"
+    subject.args[:proposal] = "default"
 
-    subject.options.merge!(
-      merge: true,
-      data: "{}"
-    )
+    subject.options[:merge] = true
+    subject.options[:data] = "{}"
 
     stub_request(:get, "http://crowbar/crowbar/testing/1.0/proposals/default")
       .with(

--- a/spec/crowbar/client/request/node/group_spec.rb
+++ b/spec/crowbar/client/request/node/group_spec.rb
@@ -1,0 +1,53 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Node::Group" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Node::Group.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+        name: "node1",
+        value: "new_group"
+      }
+    end
+
+    let!(:params) do
+      {}
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "nodes/groups/1.0/node1/new_group"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/json",
+        "Accept" => "application/json"
+      }
+    end
+  end
+end


### PR DESCRIPTION
* Drop no-alias, no-name option from node list
* Added more columns to node list output
* Added option to hide meta data on node list
* Added group subcommand for nodes

~~**This pull request depends on https://github.com/crowbar/crowbar-core/pull/183 and 
https://github.com/crowbar/crowbar-core/pull/184**~~