### PR TITLE
adapt to new installer path

### DIFF
--- a/lib/crowbar/client/request/installer/start.rb
+++ b/lib/crowbar/client/request/installer/start.rb
@@ -34,6 +34,7 @@ module Crowbar
           def url
             [
               "installer",
+              "installer",
               "start"
             ].join("/")
           end

--- a/lib/crowbar/client/request/installer/status.rb
+++ b/lib/crowbar/client/request/installer/status.rb
@@ -26,6 +26,7 @@ module Crowbar
           def url
             [
               "installer",
+              "installer",
               "status"
             ].join("/")
           end

--- a/spec/crowbar/client/request/installer/start_spec.rb
+++ b/spec/crowbar/client/request/installer/start_spec.rb
@@ -42,7 +42,7 @@ describe "Crowbar::Client::Request::Installer::Start" do
     end
 
     let!(:url) do
-      "installer/start"
+      "installer/installer/start"
     end
 
     let!(:headers) do

--- a/spec/crowbar/client/request/installer/status_spec.rb
+++ b/spec/crowbar/client/request/installer/status_spec.rb
@@ -52,7 +52,7 @@ describe "Crowbar::Client::Request::Installer::Status" do
     end
 
     let!(:url) do
-      "installer/status"
+      "installer/installer/status"
     end
 
     let!(:headers) do


### PR DESCRIPTION
The installer moved to a new path. Crowbarctl needs to be adapted.

There were no failures in mkcloud runs so far, because we trigger the installation via curl and (temporarily) support both the old and new path.