### PR TITLE
Renamed --anonymous short flag

### DIFF
--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -56,7 +56,7 @@ module Crowbar
         class_option :anonymous,
           type: :boolean,
           default: Config.defaults[:anonymous],
-          aliases: ["-a"],
+          aliases: ["-A"],
           desc: "Skip API user authentication"
 
         class_option :debug,


### PR DESCRIPTION
As the short flag of --anonymous is already taken by the --alias short
flag I have renamed the short flag of --anonymous to -A