### PR TITLE
bsc#976537 raise default timeout

### DIFF
--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -135,7 +135,7 @@ module Crowbar
         if ENV["CROWBAR_TIMEOUT"].present?
           ENV["CROWBAR_TIMEOUT"].to_i
         else
-          60
+          180
         end
       end
 


### PR DESCRIPTION
In large setups with many nodes, a backup creation can take more than
60 seconds

https://bugzilla.suse.com/show_bug.cgi?id=976537