### PR TITLE
Clarify the command role show

### DIFF
--- a/lib/crowbar/client/app/role.rb
+++ b/lib/crowbar/client/app/role.rb
@@ -83,8 +83,8 @@ module Crowbar
           "Show details of a specific role"
 
         long_desc <<-LONGDESC
-          `show BARCLAMP ROLE` will print out the details for a specified
-          role for the specified barclamp. You can display the details in
+          `show BARCLAMP ROLE` will print out the nodes available to
+          assign the role. You can display the details in
           different output formats and you can filter the details by any
           search criteria.
 

--- a/lib/crowbar/client/command/role/show.rb
+++ b/lib/crowbar/client/command/role/show.rb
@@ -41,7 +41,7 @@ module Crowbar
               when 200
                 formatter = Formatter::Array.new(
                   format: provide_format,
-                  headings: ["Node"],
+                  headings: ["Nodes available to assign the role"],
                   values: Filter::Array.new(
                     filter: provide_filter,
                     values: content_from(request)
@@ -49,7 +49,7 @@ module Crowbar
                 )
 
                 if formatter.empty?
-                  err "No nodes"
+                  err "No nodes available to assign the role"
                 else
                   say formatter.result
                 end


### PR DESCRIPTION
Seems that the description and output of
role show BARCLAMP ROLE was not clear.
This patch makes it a bit clearer in both
the command help and the table header.