### PR TITLE
Add upgrade subcommand

### DIFF
--- a/lib/crowbar/client/app.rb
+++ b/lib/crowbar/client/app.rb
@@ -62,6 +62,9 @@ module Crowbar
       autoload :Server,
         File.expand_path("../app/server", __FILE__)
 
+      autoload :Upgrade,
+        File.expand_path("../app/upgrade", __FILE__)
+
       autoload :VirtualIP,
         File.expand_path("../app/virtual_ip", __FILE__)
     end

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -142,6 +142,10 @@ module Crowbar
         desc "installer [COMMANDS]",
           "Installer specific commands, call without params for help"
         subcommand "installer", Crowbar::Client::App::Installer
+
+        desc "upgrade [COMMANDS]",
+          "Upgrade specific commands, call without params for help"
+        subcommand "upgrade", Crowbar::Client::App::Upgrade
       end
     end
   end

--- a/lib/crowbar/client/app/upgrade.rb
+++ b/lib/crowbar/client/app/upgrade.rb
@@ -1,0 +1,280 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module App
+      #
+      # A Thor based CLI wrapper for upgrade commands
+      #
+      class Upgrade < Base
+        desc "status",
+          "Show the status of the upgrade"
+
+        long_desc <<-LONGDESC
+          `status` will print out a status of the upgrade.
+          You can display the status in different output formats
+          and you can filter the list by any search criteria.
+
+          With --format <format> option you can choose an output format
+          with the available options table, json or plain. You can also
+          use the shortcut options --table, --json or --plain.
+
+          With --filter <filter> option you can limit the result of
+          printed out elements. You can use any substring that is part
+          of the found elements.
+        LONGDESC
+
+        method_option :format,
+          type: :string,
+          default: "table",
+          banner: "<format>",
+          desc: "Format of the output, valid formats are table, json or plain"
+
+        method_option :table,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format table option"
+
+        method_option :json,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format json option"
+
+        method_option :plain,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format plain option"
+
+        method_option :filter,
+          type: :string,
+          default: nil,
+          banner: "<filter>",
+          desc: "Filter by criteria, display only data that contains filter"
+
+        def status
+          Command::Upgrade::Status.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "prepare",
+          "Prepare Crowbar upgrade"
+
+        long_desc <<-LONGDESC
+          `prepare` will set the nodes to upgrading state
+        LONGDESC
+
+        def prepare
+          Command::Upgrade::Prepare.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "services",
+          "Stop related services on all nodes during upgrade"
+
+        long_desc <<-LONGDESC
+          `services` will stop all related services on all nodes
+          during the upgrade.
+
+          With --format <format> option you can choose an output format
+          with the available options table, json or plain. You can also
+          use the shortcut options --table, --json or --plain.
+
+          With --filter <filter> option you can limit the result of
+          printed out rows. You can use any substring that is part of
+          the found rows.
+        LONGDESC
+
+        def services
+          Command::Upgrade::Services.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "prechecks",
+          "Perform checks to make sure Crowbar can be upgraded"
+
+        long_desc <<-LONGDESC
+          `prechecks` will perform a sanity check on the Crowbar server to
+          make sure that the server, nodes and services can be upgraded.
+
+          With --format <format> option you can choose an output format
+          with the available options table, json or plain. You can also
+          use the shortcut options --table, --json or --plain.
+
+          With --filter <filter> option you can limit the result of
+          printed out rows. You can use any substring that is part of
+          the found rows.
+        LONGDESC
+
+        method_option :format,
+          type: :string,
+          default: "table",
+          banner: "<format>",
+          desc: "Format of the output, valid formats are table, json or plain"
+
+        method_option :table,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format table option"
+
+        method_option :json,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format json option"
+
+        method_option :plain,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format plain option"
+
+        method_option :filter,
+          type: :string,
+          default: nil,
+          banner: "<filter>",
+          desc: "Filter by criteria, display only data that contains filter"
+
+        def prechecks
+          Command::Upgrade::Prechecks.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "crowbar",
+          "Upgrade Crowbar"
+
+        long_desc <<-LONGDESC
+          `crowbar` will upgrade the operating system of the Crowbar server.
+        LONGDESC
+
+        def crowbar
+          Command::Upgrade::Crowbar.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "node NODE",
+          "Upgrade a single node"
+
+        long_desc <<-LONGDESC
+          `node NODE` will upgrade the operating system of a single node.
+        LONGDESC
+
+        def node(node)
+          Command::Upgrade::Node.new(
+            *command_params(
+              node: node
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "backup COMPONENT",
+          "Create a backup of a component (crowbar|openstack)"
+
+        long_desc <<-LONGDESC
+          `backup COMPONENT` will create a backup of Crowbar or the
+          OpenStack database. COMPONENT can be 'crowbar' or 'openstack'
+        LONGDESC
+
+        def backup(component)
+          Command::Upgrade::Backup.new(
+            *command_params(
+              component: component
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "repocheck ADDON",
+          "Check for existing repositories for an addon (ha|storage)"
+
+        long_desc <<-LONGDESC
+          `repocheck ADDON` will check for existing repositories
+          for a specifix addon product. ADDON can be 'storage' or 'ha'
+
+          With --format <format> option you can choose an output format
+          with the available options table, json or plain. You can also
+          use the shortcut options --table, --json or --plain.
+
+          With --filter <filter> option you can limit the result of
+          printed out rows. You can use any substring that is part of
+          the found rows.
+        LONGDESC
+
+        method_option :format,
+          type: :string,
+          default: "table",
+          banner: "<format>",
+          desc: "Format of the output, valid formats are table, json or plain"
+
+        method_option :table,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format table option"
+
+        method_option :json,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format json option"
+
+        method_option :plain,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format plain option"
+
+        method_option :filter,
+          type: :string,
+          default: nil,
+          banner: "<filter>",
+          desc: "Filter by criteria, display only data that contains filter"
+
+        def repocheck(addon)
+          Command::Upgrade::Repocheck.new(
+            *command_params(
+              addon: addon
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command.rb
+++ b/lib/crowbar/client/command.rb
@@ -56,6 +56,9 @@ module Crowbar
       autoload :Server,
         File.expand_path("../command/server", __FILE__)
 
+      autoload :Upgrade,
+        File.expand_path("../command/upgrade", __FILE__)
+
       autoload :VirtualIP,
         File.expand_path("../command/virtual_ip", __FILE__)
     end

--- a/lib/crowbar/client/command/upgrade.rb
+++ b/lib/crowbar/client/command/upgrade.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      #
+      # Module for the upgrade command implementations
+      #
+      module Upgrade
+        autoload :Backup,
+          File.expand_path("../upgrade/backup", __FILE__)
+
+        autoload :Crowbar,
+          File.expand_path("../upgrade/crowbar", __FILE__)
+
+        autoload :Node,
+          File.expand_path("../upgrade/node", __FILE__)
+
+        autoload :Prechecks,
+          File.expand_path("../upgrade/prechecks", __FILE__)
+
+        autoload :Prepare,
+          File.expand_path("../upgrade/prepare", __FILE__)
+
+        autoload :Repocheck,
+          File.expand_path("../upgrade/repocheck", __FILE__)
+
+        autoload :Services,
+          File.expand_path("../upgrade/services", __FILE__)
+
+        autoload :Status,
+          File.expand_path("../upgrade/status", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/backup.rb
+++ b/lib/crowbar/client/command/upgrade/backup.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade backup command
+        #
+        class Backup < Base
+          def request
+            @request ||= Request::Upgrade::Backup.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully created backup for #{args.component}"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/crowbar.rb
+++ b/lib/crowbar/client/command/upgrade/crowbar.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade crowbar command
+        #
+        class Crowbar < Base
+          def request
+            @request ||= Request::Upgrade::Crowbar.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Triggered Crowbar operating system upgrade"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/node.rb
+++ b/lib/crowbar/client/command/upgrade/node.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade node command
+        #
+        class Node < Base
+          def request
+            @request ||= Request::Upgrade::Node.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully triggered node upgrade on #{args.id}"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/prechecks.rb
+++ b/lib/crowbar/client/command/upgrade/prechecks.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade status command
+        #
+        class Prechecks < Base
+          include Mixin::Format
+          include Mixin::Filter
+
+          def request
+            @request ||= Request::Upgrade::Prechecks.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Nested.new(
+                  format: provide_format,
+                  headings: ["Check", "Successful"],
+                  values: Filter::Subset.new(
+                    filter: provide_filter,
+                    values: request.parsed_response
+                  ).result
+                )
+
+                if formatter.empty?
+                  err "No checks"
+                else
+                  say formatter.result
+                end
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/prepare.rb
+++ b/lib/crowbar/client/command/upgrade/prepare.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade prepare command
+        #
+        class Prepare < Base
+          def request
+            @request ||= Request::Upgrade::Prepare.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Setting nodes to upgrade state"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/repocheck.rb
+++ b/lib/crowbar/client/command/upgrade/repocheck.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade repocheck command
+        #
+        class Repocheck < Base
+          include Mixin::Format
+          include Mixin::Filter
+
+          def request
+            @request ||= Request::Upgrade::Repocheck.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Nested.new(
+                  format: provide_format,
+                  headings: ["Status", "Value"],
+                  values: Filter::Subset.new(
+                    filter: provide_filter,
+                    values: request.parsed_response
+                  ).result
+                )
+
+                if formatter.empty?
+                  err "No repochecks"
+                else
+                  say formatter.result
+                end
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/services.rb
+++ b/lib/crowbar/client/command/upgrade/services.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade services command
+        #
+        class Services < Base
+          def request
+            @request ||= Request::Upgrade::Services.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Stopping related services on all nodes"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/upgrade/status.rb
+++ b/lib/crowbar/client/command/upgrade/status.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Upgrade
+        #
+        # Implementation for the upgrade status command
+        #
+        class Status < Base
+          include Mixin::Format
+          include Mixin::Filter
+
+          def request
+            @request ||= Request::Upgrade::Status.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Nested.new(
+                  format: provide_format,
+                  headings: ["Status", "Value"],
+                  values: Filter::Subset.new(
+                    filter: provide_filter,
+                    values: request.parsed_response
+                  ).result
+                )
+
+                if formatter.empty?
+                  err "No status"
+                else
+                  say formatter.result
+                end
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request.rb
+++ b/lib/crowbar/client/request.rb
@@ -59,6 +59,9 @@ module Crowbar
       autoload :Server,
         File.expand_path("../request/server", __FILE__)
 
+      autoload :Upgrade,
+        File.expand_path("../request/upgrade", __FILE__)
+
       autoload :VirtualIP,
         File.expand_path("../request/virtual_ip", __FILE__)
     end

--- a/lib/crowbar/client/request/upgrade.rb
+++ b/lib/crowbar/client/request/upgrade.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      #
+      # Module for the upgrade request implementations
+      #
+      module Upgrade
+        autoload :Backup,
+          File.expand_path("../upgrade/backup", __FILE__)
+
+        autoload :Crowbar,
+          File.expand_path("../upgrade/crowbar", __FILE__)
+
+        autoload :Node,
+          File.expand_path("../upgrade/node", __FILE__)
+
+        autoload :Prechecks,
+          File.expand_path("../upgrade/prechecks", __FILE__)
+
+        autoload :Prepare,
+          File.expand_path("../upgrade/prepare", __FILE__)
+
+        autoload :Repocheck,
+          File.expand_path("../upgrade/repocheck", __FILE__)
+
+        autoload :Services,
+          File.expand_path("../upgrade/services", __FILE__)
+
+        autoload :Status,
+          File.expand_path("../upgrade/status", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/backup.rb
+++ b/lib/crowbar/client/request/upgrade/backup.rb
@@ -1,0 +1,83 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade backup request
+        #
+        class Backup < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              backup: {
+                name: "crowbar_upgrade_#{Time.now.to_i}"
+              }
+            ) if attrs.component == "crowbar"
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            case attrs.component
+            when "crowbar"
+              [
+                "api",
+                "crowbar",
+                "backups"
+              ].join("/")
+            when "openstack"
+              [
+                "api",
+                "openstack",
+                "backup"
+              ].join("/")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/crowbar.rb
+++ b/lib/crowbar/client/request/upgrade/crowbar.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade crowbar request
+        #
+        class Crowbar < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "crowbar",
+              "upgrade"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/node.rb
+++ b/lib/crowbar/client/request/upgrade/node.rb
@@ -1,0 +1,75 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade node request
+        #
+        class Node < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              node: attrs.node
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "nodes",
+              attrs.node,
+              "upgrade"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/prechecks.rb
+++ b/lib/crowbar/client/request/upgrade/prechecks.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade prechecks request
+        #
+        class Prechecks < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "upgrade",
+              "prechecks"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/prepare.rb
+++ b/lib/crowbar/client/request/upgrade/prepare.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade prepare request
+        #
+        class Prepare < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "upgrade",
+              "prepare"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/repocheck.rb
+++ b/lib/crowbar/client/request/upgrade/repocheck.rb
@@ -1,0 +1,72 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade repocheck request
+        #
+        class Repocheck < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            case attrs.addon
+            when "storage"
+              [
+                "api",
+                "storages",
+                "repocheck"
+              ].join("/")
+            when "ha"
+              [
+                "api",
+                "clusters",
+                "repocheck"
+              ].join("/")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/services.rb
+++ b/lib/crowbar/client/request/upgrade/services.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade services request
+        #
+        class Services < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "upgrade",
+              "services"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/upgrade/status.rb
+++ b/lib/crowbar/client/request/upgrade/status.rb
@@ -1,0 +1,62 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Upgrade
+        #
+        # Implementation for the upgrade status request
+        #
+        class Status < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "api",
+              "upgrade"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/backup_spec.rb
+++ b/spec/crowbar/client/command/upgrade/backup_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Backup" do
+  include_context "command_context"
+
+  ["crowbar", "openstack"].each do |component|
+    it_behaves_like "a command class", true do
+      subject do
+        ::Crowbar::Client::Command::Upgrade::Backup.new(
+          stdin,
+          stdout,
+          stderr,
+          component: component
+        )
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/crowbar_spec.rb
+++ b/spec/crowbar/client/command/upgrade/crowbar_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Crowbar" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Crowbar.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/node_spec.rb
+++ b/spec/crowbar/client/command/upgrade/node_spec.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Node" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Node.new(
+        stdin,
+        stdout,
+        stderr,
+        id: 1
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/prechecks_spec.rb
+++ b/spec/crowbar/client/command/upgrade/prechecks_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Prepare" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Prepare.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/prepare_spec.rb
+++ b/spec/crowbar/client/command/upgrade/prepare_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Prechecks" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Prechecks.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/repocheck_spec.rb
+++ b/spec/crowbar/client/command/upgrade/repocheck_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Backup" do
+  include_context "command_context"
+
+  ["ha", "storage"].each do |addon|
+    it_behaves_like "a command class", true do
+      subject do
+        ::Crowbar::Client::Command::Upgrade::Backup.new(
+          stdin,
+          stdout,
+          stderr,
+          addon: addon
+        )
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/services_spec.rb
+++ b/spec/crowbar/client/command/upgrade/services_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Services" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Services.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/upgrade/status_spec.rb
+++ b/spec/crowbar/client/command/upgrade/status_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Upgrade::Status" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Upgrade::Status.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/request/rest_spec.rb
+++ b/spec/crowbar/client/request/rest_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE Linux GmbH
+# Copyright 2016, SUSE Linux GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 require_relative "../../../spec_helper"
 
-describe "Crowbar::Client::Request::Party" do
-  subject { ::Crowbar::Client::Request::Party }
+describe "Crowbar::Client::Request::Rest" do
+  subject { ::Crowbar::Client::Request::Rest }
 
   pending
 

--- a/spec/crowbar/client/request/upgrade/backup_spec.rb
+++ b/spec/crowbar/client/request/upgrade/backup_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Backup" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Backup.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+        component: "openstack"
+      }
+    end
+
+    let!(:params) do
+      nil
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "api/openstack/backup"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/crowbar_spec.rb
+++ b/spec/crowbar/client/request/upgrade/crowbar_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Crowbar" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Crowbar.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+      }
+    end
+
+    let!(:params) do
+      {
+      }
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "api/crowbar/upgrade"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/node_spec.rb
+++ b/spec/crowbar/client/request/upgrade/node_spec.rb
@@ -1,0 +1,55 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Node" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Node.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+        node: 1
+      }
+    end
+
+    let!(:params) do
+      {
+        node: 1
+      }
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "api/nodes/1/upgrade"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/prechecks_spec.rb
+++ b/spec/crowbar/client/request/upgrade/prechecks_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Prechecks" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Prechecks.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+      }
+    end
+
+    let!(:params) do
+      {
+      }
+    end
+
+    let!(:method) do
+      :get
+    end
+
+    let!(:url) do
+      "api/upgrade/prechecks"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/prepare_spec.rb
+++ b/spec/crowbar/client/request/upgrade/prepare_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Prepare" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Prepare.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+      }
+    end
+
+    let!(:params) do
+      {
+      }
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "api/upgrade/prepare"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/repocheck_spec.rb
+++ b/spec/crowbar/client/request/upgrade/repocheck_spec.rb
@@ -1,0 +1,56 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Repocheck" do
+  [["clusters", "ha"], ["storages", "storage"]].each do |addon|
+    it_behaves_like "a request class", true do
+      subject do
+        ::Crowbar::Client::Request::Upgrade::Repocheck.new(
+          attrs
+        )
+      end
+
+      let!(:attrs) do
+        {
+          addon: addon.last
+        }
+      end
+
+      let!(:params) do
+        {
+        }
+      end
+
+      let!(:method) do
+        :get
+      end
+
+      let!(:url) do
+        "api/#{addon.first}/repocheck"
+      end
+
+      let!(:headers) do
+        {
+          "Content-Type" => "application/vnd.crowbar.v2.0+json",
+          "Accept" => "application/vnd.crowbar.v2.0+json"
+        }
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/services_spec.rb
+++ b/spec/crowbar/client/request/upgrade/services_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Services" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Services.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+      }
+    end
+
+    let!(:params) do
+      {
+      }
+    end
+
+    let!(:method) do
+      :post
+    end
+
+    let!(:url) do
+      "api/upgrade/services"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/upgrade/status_spec.rb
+++ b/spec/crowbar/client/request/upgrade/status_spec.rb
@@ -1,0 +1,53 @@
+
+#
+# Copyright 2016, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Upgrade::Status" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Upgrade::Status.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) do
+      {
+      }
+    end
+
+    let!(:params) do
+      {
+      }
+    end
+
+    let!(:method) do
+      :get
+    end
+
+    let!(:url) do
+      "api/upgrade"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/vnd.crowbar.v2.0+json",
+        "Accept" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end


### PR DESCRIPTION
```
Commands:
  crowbarctl upgrade backup COMPONENT  # Create a backup of a component (crowbar|openstack)
  crowbarctl upgrade crowbar           # Upgrade Crowbar
  crowbarctl upgrade help [COMMAND]    # Describe subcommands or one specific subcommand
  crowbarctl upgrade node NODE         # Upgrade a single node
  crowbarctl upgrade prechecks         # Perform checks to make sure Crowbar can be upgraded
  crowbarctl upgrade prepare           # Prepare Crowbar upgrade
  crowbarctl upgrade repocheck ADDON   # Check for existing repositories for an addon (ha|storage)
  crowbarctl upgrade services          # Stop related services on all nodes during upgrade
  crowbarctl upgrade status            # Show the status of the upgrade
```