### PR TITLE
Enable configuring the api version

### DIFF
--- a/config/crowbarrc
+++ b/config/crowbarrc
@@ -3,3 +3,4 @@ server = http://localhost:80
 username = crowbar
 password = crowbar
 anonymous = false
+apiversion = 2.0

--- a/lib/crowbar/client/app/base.rb
+++ b/lib/crowbar/client/app/base.rb
@@ -43,6 +43,7 @@ module Crowbar
               :server,
               :timeout,
               :anonymous,
+              :apiversion,
               :debug
             )
           )

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -69,6 +69,12 @@ module Crowbar
           aliases: ["-A"],
           desc: "Skip API user authentication"
 
+        class_option :apiversion,
+          type: :numeric,
+          default: Config.defaults[:apiversion],
+          aliases: ["-v"],
+          desc: "Select Crowbar API version"
+
         class_option :debug,
           type: :boolean,
           default: Config.defaults[:debug],

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -57,6 +57,7 @@ module Crowbar
           server: default_server,
           timeout: default_timeout,
           anonymous: default_anonymous,
+          apiversion: default_apiversion,
           debug: default_debug
         )
       end
@@ -151,6 +152,21 @@ module Crowbar
           ].include? ENV["CROWBAR_ANONYMOUS"]
         else
           false
+        end
+      end
+
+      #
+      # Define a default api version
+      #
+      # @return [Float] the default crowbar api version
+      #
+      def default_apiversion
+        if ENV["CROWBAR_APIVERSION"].present?
+          [
+            1.0, 2.0
+          ].include? ENV["CROWBAR_APIVERSION"]
+        else
+          2.0
         end
       end
 

--- a/lib/crowbar/client/request/backup/create.rb
+++ b/lib/crowbar/client/request/backup/create.rb
@@ -31,7 +31,7 @@ module Crowbar
           #
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -63,11 +63,19 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups"
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups"
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups"
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/request/backup/delete.rb
+++ b/lib/crowbar/client/request/backup/delete.rb
@@ -31,7 +31,7 @@ module Crowbar
           #
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -50,12 +50,21 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups",
-              attrs.name
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups",
+                attrs.name
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups",
+                attrs.name
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/request/backup/download.rb
+++ b/lib/crowbar/client/request/backup/download.rb
@@ -26,7 +26,7 @@ module Crowbar
         class Download < Base
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -45,13 +45,23 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups",
-              attrs.name,
-              "download"
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups",
+                attrs.name,
+                "download"
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups",
+                attrs.name,
+                "download"
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/request/backup/list.rb
+++ b/lib/crowbar/client/request/backup/list.rb
@@ -31,7 +31,7 @@ module Crowbar
           #
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -50,11 +50,19 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups"
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups"
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups"
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/request/backup/restore.rb
+++ b/lib/crowbar/client/request/backup/restore.rb
@@ -31,7 +31,7 @@ module Crowbar
           #
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -50,13 +50,23 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups",
-              attrs.name,
-              "restore"
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups",
+                attrs.name,
+                "restore"
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups",
+                attrs.name,
+                "restore"
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/request/backup/upload.rb
+++ b/lib/crowbar/client/request/backup/upload.rb
@@ -31,7 +31,7 @@ module Crowbar
           #
           def headers
             super.easy_merge!(
-              Crowbar::Client::Util::ApiVersion.new(2.0).headers
+              Crowbar::Client::Util::ApiVersion.new(Config.apiversion).headers
             )
           end
 
@@ -61,12 +61,21 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "crowbar",
-              "backups",
-              "upload"
-            ].join("/")
+            case Config.apiversion
+            when 1.0
+              [
+                "utils",
+                "backups",
+                "upload"
+              ]
+            when 2.0
+              [
+                "api",
+                "crowbar",
+                "backups",
+                "upload"
+              ]
+            end.join("/")
           end
         end
       end

--- a/lib/crowbar/client/util/apiversion.rb
+++ b/lib/crowbar/client/util/apiversion.rb
@@ -25,10 +25,17 @@ module Crowbar
         end
 
         def headers
-          {
-            "Accept" => "application/vnd.crowbar.v#{version}+json",
-            "Content-Type" => "application/vnd.crowbar.v#{version}+json"
-          }
+          if version == 1.0
+            {
+              "Accept" => "application/json",
+              "Content-Type" => "application/json"
+            }
+          else
+            {
+              "Accept" => "application/vnd.crowbar.v#{version}+json",
+              "Content-Type" => "application/vnd.crowbar.v#{version}+json"
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
The problem is that crowbar-client, as a rubygem is shared between cloud versions.
to not break the older cloud versions, we need to be able to differentiate when we have api endpoints that have changed/moved