### PR TITLE
replace case with unless as when does not work with this negation

### DIFF
--- a/lib/crowbar/client/command/upgrade/database.rb
+++ b/lib/crowbar/client/command/upgrade/database.rb
@@ -48,8 +48,7 @@ module Crowbar
             request.process do |request|
               response = JSON.parse(request.body)
 
-              case request.code
-              when !200
+              unless request.code == 200
                 err request.parsed_response["error"]
               end
 


### PR DESCRIPTION
and it is only one case, so it is not really necessary to use case