### PR TITLE
Catch potential nil body of response

### DIFF
--- a/lib/crowbar/client/command/upgrade/database.rb
+++ b/lib/crowbar/client/command/upgrade/database.rb
@@ -50,7 +50,7 @@ module Crowbar
                 err request.parsed_response["error"]
               end
 
-              response = JSON.parse(request.body)
+              response = JSON.parse(request.body) unless request.body.nil?
 
               steps_with_messages.each do |step, message|
                 next if response[step.to_s]["success"]


### PR DESCRIPTION
Under error, the response.body is nil and should not be stuffed into the JSON
parser.