### PR TITLE
adapt to the new api requirement

### DIFF
--- a/lib/crowbar/client/request/upgrade/backup.rb
+++ b/lib/crowbar/client/request/upgrade/backup.rb
@@ -67,8 +67,8 @@ module Crowbar
             when "crowbar"
               [
                 "api",
-                "crowbar",
-                "backups"
+                "upgrade",
+                "adminbackup"
               ].join("/")
             when "openstack"
               [


### PR DESCRIPTION
an additional POST parameter is now required to determine if we
are creating the backup in an upgrade case

### depends on
https://github.com/crowbar/crowbar-core/pull/770
and its yet non existing backport