### PR TITLE
make the check_id server agnostic

### DIFF
--- a/lib/crowbar/client/command/upgrade/prechecks.rb
+++ b/lib/crowbar/client/command/upgrade/prechecks.rb
@@ -60,6 +60,10 @@ module Crowbar
           def content_from(request)
             [].tap do |row|
               request.parsed_response["checks"].each do |check_id, values|
+                # make the check_id server agnostic
+                # the check_id could be named differently in the server response
+                check_id = values["errors"].keys.first if values["errors"].any?
+
                 row.push(
                   check_id: check_id,
                   passed: values["passed"],


### PR DESCRIPTION
to not be dependent on the server response when it comes to a check
id, try to extract the check_id from the server error response.

the error response is wrapped into a check_id as well and it is safe
to extract it from there in case that it exists.

on top of that it should be insured that every error response is
wrapped into the same check_id as the top level check_id to provide
additional security. (EDIT: which is not really possible ATM, see NOTE below)


### NOTE

an example would be https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/app/models/api/upgrade.rb#L434

`clusters_health_crm_failures`

it is different than the `check_id` which is called `clusters_healthy` in that case
(see https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/app/models/api/upgrade.rb#L57)

so `if values["errors"].key?(check_id)` will never trigger true.