### PR TITLE
hand over timeout to rest-client

### DIFF
--- a/lib/crowbar/client/request/rest.rb
+++ b/lib/crowbar/client/request/rest.rb
@@ -36,7 +36,8 @@ module Crowbar
             ].join(""),
             user: user,
             password: password,
-            auth_type: auth_type
+            auth_type: auth_type,
+            timeout: Config.timeout
           )
         end
       end


### PR DESCRIPTION
the default is 60 seconds, and it should be handed over as set in
crowbarctl's config.

this must have been forgotten when switching to rest-client.