### PR TITLE
rest-client: use the correct api response in case of an error

### DIFF
--- a/lib/crowbar/client/command/upgrade/backup.rb
+++ b/lib/crowbar/client/command/upgrade/backup.rb
@@ -22,6 +22,8 @@ module Crowbar
         # Implementation for the upgrade backup command
         #
         class Backup < Base
+          include Mixin::UpgradeError
+
           def request
             @request ||= Request::Upgrade::Backup.new(
               args
@@ -34,7 +36,18 @@ module Crowbar
               when 200
                 say "Successfully created backup for #{args.component}"
               else
-                err request.parsed_response["error"]
+                case args.component
+                when "crowbar"
+                  err format_error(
+                    request.parsed_response["error"], "admin_backup"
+                  )
+                when "openstack"
+                  err format_error(
+                    request.parsed_response["error"], "nodes_db_dump"
+                  )
+                else
+                  request.parsed_response["error"]
+                end
               end
             end
           end

--- a/lib/crowbar/client/command/upgrade/nodes.rb
+++ b/lib/crowbar/client/command/upgrade/nodes.rb
@@ -22,6 +22,8 @@ module Crowbar
         # Implementation for the upgrade nodes command
         #
         class Nodes < Base
+          include Mixin::UpgradeError
+
           def request
             @request ||= Request::Upgrade::Nodes.new(
               args
@@ -34,7 +36,9 @@ module Crowbar
               when 200
                 say "Successfully triggered the upgrade of the nodes"
               else
-                err request.parsed_response["error"]
+                err format_error(
+                  request.parsed_response["error"], "nodes_upgrade"
+                )
               end
             end
           end

--- a/lib/crowbar/client/command/upgrade/prepare.rb
+++ b/lib/crowbar/client/command/upgrade/prepare.rb
@@ -22,6 +22,8 @@ module Crowbar
         # Implementation for the upgrade prepare command
         #
         class Prepare < Base
+          include Mixin::UpgradeError
+
           def request
             @request ||= Request::Upgrade::Prepare.new(
               args
@@ -34,7 +36,9 @@ module Crowbar
               when 200
                 say "Setting nodes to upgrade state"
               else
-                err request.parsed_response["error"]
+                err format_error(
+                  request.parsed_response["error"], "upgrade_prepare"
+                )
               end
             end
           end

--- a/lib/crowbar/client/command/upgrade/repocheck.rb
+++ b/lib/crowbar/client/command/upgrade/repocheck.rb
@@ -24,6 +24,7 @@ module Crowbar
         class Repocheck < Base
           include Mixin::Format
           include Mixin::Filter
+          include Mixin::UpgradeError
 
           def request
             @request ||= Request::Upgrade::Repocheck.new(
@@ -50,7 +51,18 @@ module Crowbar
                   say formatter.result
                 end
               else
-                err request.parsed_response["error"]
+                case args.component
+                when "crowbar"
+                  err format_error(
+                    request.parsed_response["error"], "admin_repo_checks"
+                  )
+                when "nodes"
+                  err format_error(
+                    request.parsed_response["error"], "nodes_repo_checks"
+                  )
+                else
+                  err request.parsed_response["error"]
+                end
               end
             end
           end

--- a/lib/crowbar/client/command/upgrade/services.rb
+++ b/lib/crowbar/client/command/upgrade/services.rb
@@ -22,6 +22,8 @@ module Crowbar
         # Implementation for the upgrade services command
         #
         class Services < Base
+          include Mixin::UpgradeError
+
           def request
             @request ||= Request::Upgrade::Services.new(
               args
@@ -34,7 +36,9 @@ module Crowbar
               when 200
                 say "Stopping related services on all nodes"
               else
-                err request.parsed_response["error"]
+                err format_error(
+                  request.parsed_response["error"], "nodes_services"
+                )
               end
             end
           end

--- a/lib/crowbar/client/mixin.rb
+++ b/lib/crowbar/client/mixin.rb
@@ -31,6 +31,9 @@ module Crowbar
 
       autoload :Filter,
         File.expand_path("../mixin/filter", __FILE__)
+
+      autoload :UpgradeError,
+        File.expand_path("../mixin/upgrade_error", __FILE__)
     end
   end
 end

--- a/lib/crowbar/client/mixin/upgrade_error.rb
+++ b/lib/crowbar/client/mixin/upgrade_error.rb
@@ -14,33 +14,22 @@
 # limitations under the License.
 #
 
+require "active_support/concern"
+
 module Crowbar
   module Client
-    module Command
-      module Upgrade
-        #
-        # Implementation for the upgrade crowbar command
-        #
-        class Crowbar < Base
-          include Mixin::UpgradeError
+    module Mixin
+      #
+      # A mixin with upgrade error related helpers
+      #
+      module UpgradeError
+        extend ActiveSupport::Concern
 
-          def request
-            @request ||= Request::Upgrade::Crowbar.new(
-              args
-            )
-          end
-
-          def execute
-            request.process do |request|
-              case request.code
-              when 200
-                say "Triggered Crowbar operating system upgrade"
-              else
-                err format_error(
-                  request.parsed_response["error"], "admin_upgrade"
-                )
-              end
-            end
+        included do
+          def format_error(response, step)
+            JSON.parse(response.body)["errors"][step]["data"]
+          rescue
+            "Unable to format error response for #{step}"
           end
         end
       end

--- a/lib/crowbar/client/request/base.rb
+++ b/lib/crowbar/client/request/base.rb
@@ -75,7 +75,7 @@ module Crowbar
             if e.class.superclass == RestClient::RequestFailed
               Hashie::Mash.new(
                 parsed_response: {
-                  error: e.message
+                  error: e.response
                 },
                 code: e.http_code
               )


### PR DESCRIPTION
e.message only displays the http error formatted as a string
r.response actually contains the response body

see http://www.rubydoc.info/gems/rest-client/RestClient/Exception