### PR TITLE
catch error 406 when node alias is not unique

### DIFF
--- a/lib/crowbar/client/command/node/rename.rb
+++ b/lib/crowbar/client/command/node/rename.rb
@@ -35,6 +35,8 @@ module Crowbar
                 say "Successfully updated alias for #{args.name}"
               when 404
                 err "Node does not exist"
+              when 406
+                err "Rename for #{args.name} failed. Node alias not unique?"
               else
                 err request.parsed_response["error"]
               end


### PR DESCRIPTION
Closing bug 1011581 - Renaming of node to already taken name via crowbarctl fails with 500 Internal Server Error.