### PR TITLE
upgrade: adapt http codes for upgrade cancel

### DIFF
--- a/lib/crowbar/client/command/upgrade/cancel.rb
+++ b/lib/crowbar/client/command/upgrade/cancel.rb
@@ -33,8 +33,10 @@ module Crowbar
               case request.code
               when 200
                 say "Canceled the upgrade process"
-              when 406
-                err "Not allowed to cancel the upgrade at this stage; Please refer to help output."
+              when 422
+                err "Failed to cancel the upgrade process"
+              when 423
+                err "Not possible to cancel the upgrade at this stage; Please refer to help output."
               else
                 err request.parsed_response["error"]
               end


### PR DESCRIPTION
* the server returns 422 on a failed cancel
* 423 now means that the cancel is not allowed

### depends on
https://github.com/crowbar/crowbar-core/pull/881