### PR TITLE
upgrade: Change endpoint of the openstack backup

### DIFF
--- a/lib/crowbar/client/request/upgrade/backup.rb
+++ b/lib/crowbar/client/request/upgrade/backup.rb
@@ -73,8 +73,8 @@ module Crowbar
             when "openstack"
               [
                 "api",
-                "openstack",
-                "backup"
+                "upgrade",
+                "openstackbackup"
               ].join("/")
             end
           end

--- a/spec/crowbar/client/request/upgrade/backup_spec.rb
+++ b/spec/crowbar/client/request/upgrade/backup_spec.rb
@@ -40,7 +40,7 @@ describe "Crowbar::Client::Request::Upgrade::Backup" do
     end
 
     let!(:url) do
-      "api/openstack/backup"
+      "api/upgrade/openstackbackup"
     end
 
     let!(:headers) do


### PR DESCRIPTION
this is now in the upgrade api of crowbar-core

## depends on
https://github.com/crowbar/crowbar-core/pull/946