### PR TITLE
upgrade: Guide user through the upgrade

### DIFF
--- a/lib/crowbar/client/command/upgrade/backup.rb
+++ b/lib/crowbar/client/command/upgrade/backup.rb
@@ -35,6 +35,10 @@ module Crowbar
               case request.code
               when 200
                 say "Successfully created backup for #{args.component}"
+                if args.component == "crowbar"
+                  say "Next step: 'crowbarctl upgrade repocheck crowbar'"
+                end
+                say "Next step: 'crowbarctl upgrade nodes'" if args.component == "openstack"
               else
                 case args.component
                 when "crowbar"

--- a/lib/crowbar/client/command/upgrade/crowbar.rb
+++ b/lib/crowbar/client/command/upgrade/crowbar.rb
@@ -35,6 +35,8 @@ module Crowbar
               case request.code
               when 200
                 say "Triggered Crowbar operating system upgrade"
+                say "Wait until the admin server is fully upgraded and rebooted."
+                say "Next step: 'crowbarctl upgrade database [new|connect]'"
               else
                 err format_error(
                   request.parsed_response["error"], "admin_upgrade"

--- a/lib/crowbar/client/command/upgrade/database.rb
+++ b/lib/crowbar/client/command/upgrade/database.rb
@@ -58,6 +58,7 @@ module Crowbar
               end
 
               say "Successfully initialized Crowbar"
+              say "Next step: 'crowbarctl upgrade repocheck nodes'"
             end
           end
 

--- a/lib/crowbar/client/command/upgrade/nodes.rb
+++ b/lib/crowbar/client/command/upgrade/nodes.rb
@@ -34,7 +34,8 @@ module Crowbar
             request.process do |request|
               case request.code
               when 200
-                say "Successfully triggered the upgrade of the nodes"
+                say "Successfully triggered the upgrade of the nodes. " \
+                  "Query the upgrade status to follow the process with 'crowbarctl upgrade status'."
               else
                 err format_error(
                   request.parsed_response["error"], "nodes_upgrade"

--- a/lib/crowbar/client/command/upgrade/prechecks.rb
+++ b/lib/crowbar/client/command/upgrade/prechecks.rb
@@ -48,6 +48,10 @@ module Crowbar
                   err "No checks"
                 else
                   say formatter.result
+                  next unless provide_format == :table
+                  say "Make sure that there are no errors for the required checks" \
+                    " before executing the next step."
+                  say "Next step: 'crowbarctl upgrade prepare'"
                 end
               else
                 err request.parsed_response["error"]

--- a/lib/crowbar/client/command/upgrade/prepare.rb
+++ b/lib/crowbar/client/command/upgrade/prepare.rb
@@ -34,7 +34,9 @@ module Crowbar
             request.process do |request|
               case request.code
               when 200
-                say "Setting nodes to upgrade state"
+                say "Setting nodes to upgrade state." \
+                  "Query the upgrade status to follow the process with 'crowbarctl upgrade status'."
+                say "Next step: 'crowbarctl upgrade backup crowbar'"
               else
                 err format_error(
                   request.parsed_response["error"], "upgrade_prepare"

--- a/lib/crowbar/client/command/upgrade/repocheck.rb
+++ b/lib/crowbar/client/command/upgrade/repocheck.rb
@@ -49,6 +49,9 @@ module Crowbar
                   err "No repochecks"
                 else
                   say formatter.result
+                  next unless provide_format == :table
+                  say "Next step: 'crowbarctl upgrade crowbar'" if args.component == "crowbar"
+                  say "Next step: 'crowbarctl upgrade services'" if args.component == "nodes"
                 end
               else
                 case args.component

--- a/lib/crowbar/client/command/upgrade/services.rb
+++ b/lib/crowbar/client/command/upgrade/services.rb
@@ -34,7 +34,9 @@ module Crowbar
             request.process do |request|
               case request.code
               when 200
-                say "Stopping related services on all nodes"
+                say "Stopping related services on all nodes." \
+                  "Query the upgrade status to follow the process with 'crowbarctl upgrade status'."
+                say "Next step: 'crowbarctl upgrade nodes'"
               else
                 err format_error(
                   request.parsed_response["error"], "nodes_services"


### PR DESCRIPTION
after a step has successfully finished, show the next step to execute
but only when no custom format (json|plain) is specified