### PR TITLE
upgrade: Next step after 'services' is openstack DB backup

### DIFF
--- a/lib/crowbar/client/command/upgrade/services.rb
+++ b/lib/crowbar/client/command/upgrade/services.rb
@@ -36,7 +36,7 @@ module Crowbar
               when 200
                 say "Stopping related services on all nodes." \
                   "Query the upgrade status to follow the process with 'crowbarctl upgrade status'."
-                say "Next step: 'crowbarctl upgrade nodes'"
+                say "Next step: 'crowbarctl upgrade backup openstack'"
               else
                 err format_error(
                   request.parsed_response["error"], "services"


### PR DESCRIPTION
Well, at least until we drop that step or make it optional...