### PR TITLE
upgrade: Add a space to the output of upgrade services

### DIFF
--- a/lib/crowbar/client/command/upgrade/services.rb
+++ b/lib/crowbar/client/command/upgrade/services.rb
@@ -34,7 +34,7 @@ module Crowbar
             request.process do |request|
               case request.code
               when 200
-                say "Stopping related services on all nodes." \
+                say "Stopping related services on all nodes. " \
                   "Query the upgrade status to follow the process with 'crowbarctl upgrade status'."
                 say "Next step: 'crowbarctl upgrade backup openstack'"
               else


### PR DESCRIPTION
otherwise it looks like `Stopping related services on all nodes.Query the upgrade status to follow the process with 'crowbarctl upgrade status'.`