### PR TITLE
upgrade: Enable querying the nodes upgrade status

### DIFF
--- a/lib/crowbar/client/app/upgrade.rb
+++ b/lib/crowbar/client/app/upgrade.rb
@@ -21,11 +21,14 @@ module Crowbar
       # A Thor based CLI wrapper for upgrade commands
       #
       class Upgrade < Base
-        desc "status",
-          "Show the status of the upgrade"
+        desc "status [nodes]",
+          "Show the status of the upgrade or the nodes upgrade"
 
         long_desc <<-LONGDESC
           `status` will print out a status of the upgrade.
+
+          `status nodes` will print out a status of the nodes upgrade.
+
           You can display the status in different output formats
           and you can filter the list by any search criteria.
 
@@ -68,9 +71,11 @@ module Crowbar
           banner: "<filter>",
           desc: "Filter by criteria, display only data that contains filter"
 
-        def status
+        def status(nodes = false)
           Command::Upgrade::Status.new(
-            *command_params
+            *command_params(
+              nodes: nodes
+            )
           ).execute
         rescue => e
           catch_errors(e)

--- a/lib/crowbar/client/request/upgrade/status.rb
+++ b/lib/crowbar/client/request/upgrade/status.rb
@@ -50,10 +50,17 @@ module Crowbar
           # @return [String] path to the API endpoint
           #
           def url
-            [
-              "api",
-              "upgrade"
-            ].join("/")
+            if attrs.nodes
+              [
+                "api",
+                "upgrade?nodes=true"
+              ].join("/")
+            else
+              [
+                "api",
+                "upgrade"
+              ].join("/")
+            end
           end
         end
       end


### PR DESCRIPTION
## depends on
https://github.com/crowbar/crowbar-core/pull/1062

## example output
```bash
➜  ✗ crowbarctl upgrade status nodes 
+--------------+---------------------------------+
| Status       | Value                           |
+--------------+---------------------------------+
| upgraded     |                                 |
| not_upgraded | d52-54-77-77-77-03.emil.suse.de |
|              | d52-54-77-77-77-01.emil.suse.de |
|              | d52-54-77-77-77-02.emil.suse.de |
|              | d52-54-77-77-77-04.emil.suse.de |
+--------------+---------------------------------+
```