### PR TITLE
upgrade: Print nodes status only when nodes attribute is given

### DIFF
--- a/lib/crowbar/client/app/upgrade.rb
+++ b/lib/crowbar/client/app/upgrade.rb
@@ -71,10 +71,10 @@ module Crowbar
           banner: "<filter>",
           desc: "Filter by criteria, display only data that contains filter"
 
-        def status(nodes = false)
+        def status(component = nil)
           Command::Upgrade::Status.new(
             *command_params(
-              nodes: nodes
+              nodes: component == "nodes"
             )
           ).execute
         rescue => e


### PR DESCRIPTION
This is a minor fix of https://github.com/crowbar/crowbar-client/pull/147