### PR TITLE
Fix json encoding for post request (bsc#1023834)

### DIFF
--- a/lib/crowbar/client/request/base.rb
+++ b/lib/crowbar/client/request/base.rb
@@ -50,7 +50,7 @@ module Crowbar
           when :post
             [
               method,
-              content
+              content.to_json
             ]
           when :put
             [


### PR DESCRIPTION
This broke requests where the body contained not string values (integers,
booleans). E.g. when trying to update a proposal using:

crowbarctl proposal edit <barclamp> default

https://bugzilla.suse.com/show_bug.cgi?id=1023834