### PR TITLE
Fix content-type sent from crowbarctl to v2 APIs

### DIFF
--- a/lib/crowbar/client/util/apiversion.rb
+++ b/lib/crowbar/client/util/apiversion.rb
@@ -33,7 +33,7 @@ module Crowbar
           else
             {
               "Accept" => "application/vnd.crowbar.v#{version}+json",
-              "Content-Type" => "application/vnd.crowbar.v#{version}+json"
+              "Content-Type" => "application/json"
             }
           end
         end


### PR DESCRIPTION
The v2 APIs require Accept header to be application/vnd.crowbar.v2.0+json
but the Content-Type should still be application/json for correct parsing
on server side.

This is an alternative to https://github.com/crowbar/crowbar-core/pull/1085