### PR TITLE
upgrade: Remove experimental marker from upgrade subcommand

### DIFF
--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -149,11 +149,9 @@ module Crowbar
           "Installer specific commands, call without params for help"
         subcommand "installer", Crowbar::Client::App::Installer
 
-        if !(Crowbar::Client::Util::ApiVersion.default == 1.0) || Config.options.experimental
-          desc "upgrade [COMMANDS]",
-            "Upgrade specific commands, call without params for help"
-          subcommand "upgrade", Crowbar::Client::App::Upgrade
-        end
+        desc "upgrade [COMMANDS]",
+          "Upgrade specific commands, call without params for help"
+        subcommand "upgrade", Crowbar::Client::App::Upgrade
 
         desc "database [COMMANDS]",
           "Database specific commands, call without params for help"


### PR DESCRIPTION
The next maintenance update will be the enablement of the upgrade process. So no need to hide it longer.