### PR TITLE
ssl: Allow skipping the SSL verification step

### DIFF
--- a/lib/crowbar/client/app/base.rb
+++ b/lib/crowbar/client/app/base.rb
@@ -41,6 +41,7 @@ module Crowbar
               :username,
               :password,
               :server,
+              :verify_ssl,
               :timeout,
               :anonymous,
               :apiversion,

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -57,6 +57,12 @@ module Crowbar
           aliases: ["-s"],
           desc: "Specify server for connection"
 
+        class_option :verify_ssl,
+          type: :boolean,
+          default: Config.defaults[:verify_ssl],
+          aliases: ["-i"],
+          desc: "Verify server SSL certificate"
+
         class_option :timeout,
           type: :numeric,
           default: Config.defaults[:timeout],

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -55,6 +55,7 @@ module Crowbar
           username: default_username,
           password: default_password,
           server: default_server,
+          verify_ssl: default_verify_ssl,
           timeout: default_timeout,
           anonymous: default_anonymous,
           apiversion: default_apiversion,
@@ -126,6 +127,21 @@ module Crowbar
       #
       def default_server
         ENV["CROWBAR_SERVER"] || "http://127.0.0.1:80"
+      end
+
+      #
+      # Define a default verify_ssl flag
+      #
+      # @return [Bool] the default verify_ssl flag
+      #
+      def default_verify_ssl
+        if ENV["CROWBAR_VERIFY_SSL"].present?
+          [
+            false, 0, "0", "f", "F", "false", "FALSE"
+          ].include? ENV["CROWBAR_VERIFY_SSL"]
+        else
+          true
+        end
       end
 
       #

--- a/lib/crowbar/client/request/rest.rb
+++ b/lib/crowbar/client/request/rest.rb
@@ -25,6 +25,7 @@ module Crowbar
           user = options.fetch(:user, Config.username)
           password = options.fetch(:password, Config.password)
           auth_type = options.fetch(:auth_type, :digest)
+          verify_ssl = options.fetch(:verify_ssl, Config.verify_ssl)
 
           Config.debug && RestClient.log = "stdout"
 
@@ -37,6 +38,7 @@ module Crowbar
             user: user,
             password: password,
             auth_type: auth_type,
+            verify_ssl: verify_ssl,
             timeout: Config.timeout
           )
         end


### PR DESCRIPTION
When we allow to deploy crowbar with https then we also have to allow to
skip the ssl verification in crowbar-client in case we use self-signed
certificates.