### PR TITLE
upgrade: "Next step" hint after admin repochecks

### DIFF
--- a/lib/crowbar/client/command/upgrade/repocheck.rb
+++ b/lib/crowbar/client/command/upgrade/repocheck.rb
@@ -50,7 +50,7 @@ module Crowbar
                 else
                   say formatter.result
                   next unless provide_format == :table
-                  say "Next step: 'crowbarctl upgrade admin'" if args.component == "admin"
+                  say "Next step: 'crowbarctl upgrade admin'" if args.component == "crowbar"
                   say "Next step: 'crowbarctl upgrade services'" if args.component == "nodes"
                 end
               else


### PR DESCRIPTION
The "Next step" hint was not displayed after admin repochecks.
One condition was not correct wrt last command renaming (i.e. crowbar vs admin).