### PR TITLE
Set timeout to 3600 seconds

### DIFF
--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -153,7 +153,7 @@ module Crowbar
         if ENV["CROWBAR_TIMEOUT"].present?
           ENV["CROWBAR_TIMEOUT"].to_i
         else
-          300
+          3600
         end
       end
 


### PR DESCRIPTION
This commit syncs the timeout with all other crowbar components, it's
also the same timeout as the old CLI is using it.