### PR TITLE
crowbar: Add new service command and subcommands for service restart management

### DIFF
--- a/lib/crowbar/client/app.rb
+++ b/lib/crowbar/client/app.rb
@@ -70,6 +70,9 @@ module Crowbar
 
       autoload :VirtualIP,
         File.expand_path("../app/virtual_ip", __FILE__)
+
+      autoload :Services,
+        File.expand_path("../app/services", __FILE__)
     end
   end
 end

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -162,6 +162,10 @@ module Crowbar
         desc "database [COMMANDS]",
           "Database specific commands, call without params for help"
         subcommand "database", Crowbar::Client::App::Database
+
+        desc "services [COMMANDS]",
+          "Services specific commands, call without params for help"
+        subcommand "services", Crowbar::Client::App::Services
       end
     end
   end

--- a/lib/crowbar/client/app/services.rb
+++ b/lib/crowbar/client/app/services.rb
@@ -1,0 +1,85 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module App
+      #
+      # A Thor based CLI wrapper for Services commands
+      #
+      class Services < Base
+        desc "list_restarts",
+             "List services that require a restart"
+
+        long_desc <<-LONGDESC
+          `list_restarts` will print out a list of the services requiring restart.
+          You can display the list in different output formats.
+        LONGDESC
+
+        def list_restarts
+          Command::Services::ListServiceRestarts.new(*command_params).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "clear_restart NODE SERVICE",
+             "Clear the restart flag for a service on a node"
+
+        long_desc <<-LONGDESC
+          `clear_restart NODE SERVICE` will clear the 'restart needed' flag
+          for the given SERVICE on the NODE.
+        LONGDESC
+        def clear_restart(node, service)
+          Command::Services::ClearServiceRestart.new(
+            *command_params(
+              node: node,
+              service: service
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "restart_flags",
+             "List cookbooks and their restart status (allowed/disallowed)"
+
+        def restart_flags
+          Command::Services::ListRestartFlags.new(*command_params).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "disable_restart COOKBOOK VALUE",
+             "Set the restart disallowed for a cookbook to true/false"
+        def disable_restart(cookbook, value)
+          unless ["true", "false"].include? value.downcase
+            msg = "#{value} is not a valid value for this command. Please use true or false"
+            raise SimpleCatchableError(msg)
+          end
+          value = value.casecmp("true").zero? ? true : false
+          Command::Services::SetRestartFlag.new(
+            *command_params(
+              cookbook: cookbook,
+              disallow_restart: value
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command.rb
+++ b/lib/crowbar/client/command.rb
@@ -64,6 +64,9 @@ module Crowbar
 
       autoload :VirtualIP,
         File.expand_path("../command/virtual_ip", __FILE__)
+
+      autoload :Services,
+        File.expand_path("../command/services", __FILE__)
     end
   end
 end

--- a/lib/crowbar/client/command/services.rb
+++ b/lib/crowbar/client/command/services.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      #
+      # Module for the List Restarts command implementations
+      #
+      module Services
+        autoload :ListServiceRestarts, File.expand_path("../services/list_restarts", __FILE__)
+        autoload :ClearServiceRestart, File.expand_path("../services/clear_restart", __FILE__)
+        autoload :ListRestartFlags, File.expand_path("../services/restart_flags", __FILE__)
+        autoload :SetRestartFlag, File.expand_path("../services/disable_restart", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/services/clear_restart.rb
+++ b/lib/crowbar/client/command/services/clear_restart.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Services
+        #
+        # Implementation for the List Restarts command
+        #
+        class ClearServiceRestart < Base
+          include Mixin::Format
+
+          def request
+            @request ||= Request::Services::ClearServiceRestart.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              err request.parsed_response["error"] if request.code != 200
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/services/disable_restart.rb
+++ b/lib/crowbar/client/command/services/disable_restart.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Services
+        #
+        # Implementation for the List Restarts command
+        #
+        class SetRestartFlag < Base
+          include Mixin::Format
+
+          def request
+            @request ||= Request::Services::SetRestartFlag.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              err request.parsed_response["error"] if request.code != 200
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/services/list_restarts.rb
+++ b/lib/crowbar/client/command/services/list_restarts.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Services
+        #
+        # Implementation for the List Restarts command
+        #
+        class ListServiceRestarts < Base
+          include Mixin::Format
+
+          def request
+            @request ||= Request::Services::ListServiceRestarts.new(
+              *args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Hash.new(
+                  format: "json",
+                  headings: ["Node"],
+                  values: request.parsed_response
+                )
+
+                if formatter.empty?
+                  err "No restarts"
+                else
+                  say formatter.result
+                end
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/services/restart_flags.rb
+++ b/lib/crowbar/client/command/services/restart_flags.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Services
+        #
+        # Implementation for the List Restarts command
+        #
+        class ListRestartFlags < Base
+          include Mixin::Format
+
+          def request
+            @request ||= Request::Services::ListRestartFlags.new(
+              *args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Hash.new(
+                  format: "json",
+                  headings: ["Barclamp"],
+                  values: request.parsed_response
+                )
+
+                if formatter.empty?
+                  err "No flags set"
+                else
+                  say formatter.result
+                end
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request.rb
+++ b/lib/crowbar/client/request.rb
@@ -70,6 +70,9 @@ module Crowbar
 
       autoload :VirtualIP,
         File.expand_path("../request/virtual_ip", __FILE__)
+
+      autoload :Services,
+        File.expand_path("../request/services", __FILE__)
     end
   end
 end

--- a/lib/crowbar/client/request/services.rb
+++ b/lib/crowbar/client/request/services.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      #
+      # Module for the List Restarts request implementations
+      #
+      module Services
+        autoload :ListServiceRestarts, File.expand_path("../services/list_restarts", __FILE__)
+        autoload :ClearServiceRestart, File.expand_path("../services/clear_restart", __FILE__)
+        autoload :ListRestartFlags, File.expand_path("../services/restart_flags", __FILE__)
+        autoload :SetRestartFlag, File.expand_path("../services/disable_restart", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/services/clear_restart.rb
+++ b/lib/crowbar/client/request/services/clear_restart.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Services
+        #
+        # Implementation for the Clear Restarts request
+        #
+        class ClearServiceRestart < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              node: attrs.node,
+              service: attrs.service
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            ["api", "restart_management", "restarts"].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/services/disable_restart.rb
+++ b/lib/crowbar/client/request/services/disable_restart.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Services
+        #
+        # Implementation for the Disable Restarts request
+        #
+        class SetRestartFlag < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              cookbook: attrs.cookbook,
+              disallow_restart: attrs.disallow_restart
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            ["api", "restart_management", "configuration"].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/services/list_restarts.rb
+++ b/lib/crowbar/client/request/services/list_restarts.rb
@@ -1,0 +1,59 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Services
+        #
+        # Implementation for the List Restarts request
+        #
+        class ListServiceRestarts < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            ["api", "restart_management", "restarts"].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/services/restart_flags.rb
+++ b/lib/crowbar/client/request/services/restart_flags.rb
@@ -1,0 +1,59 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Services
+        #
+        # Implementation for the Restarts Flags request
+        #
+        class ListRestartFlags < Base
+          #
+          # Override the request headers
+          #
+          # @return [Hash] the headers for the request
+          #
+          def headers
+            super.easy_merge!(
+              ::Crowbar::Client::Util::ApiVersion.new(2.0).headers
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            ["api", "restart_management", "configuration"].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/command/services/clear_restart_spec.rb
+++ b/spec/crowbar/client/command/services/clear_restart_spec.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Services::ClearServiceRestart" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Services::ClearServiceRestart.new(
+        stdin,
+        stdout,
+        stderr,
+        node: "test",
+        service: "test"
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/services/disable_restart_spec.rb
+++ b/spec/crowbar/client/command/services/disable_restart_spec.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Services::SetRestartFlag" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Services::SetRestartFlag.new(
+        stdin,
+        stdout,
+        stderr,
+        cookbook: "test",
+        disallow_restart: "false"
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/services/list_restarts_spec.rb
+++ b/spec/crowbar/client/command/services/list_restarts_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Services::ListServiceRestarts" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Services::ListServiceRestarts.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/command/services/restart_flags_spec.rb
+++ b/spec/crowbar/client/command/services/restart_flags_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Command::Services::ListRestartFlags" do
+  include_context "command_context"
+
+  it_behaves_like "a command class", true do
+    subject do
+      ::Crowbar::Client::Command::Services::ListRestartFlags.new(
+        stdin,
+        stdout,
+        stderr
+      )
+    end
+  end
+end

--- a/spec/crowbar/client/request/services/clear_restart_spec.rb
+++ b/spec/crowbar/client/request/services/clear_restart_spec.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+header = "application/vnd.crowbar.v2.0+json"
+
+describe "Crowbar::Client::Request::Services::ClearServiceRestart" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Services::ClearServiceRestart.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) { { node: "test", service: "test" } }
+    let!(:params) { { node: "test", service: "test" } }
+    let!(:method) { :post }
+    let!(:url) { "api/restart_management/restarts" }
+    let!(:headers) { { "Accept" => header, "Content-Type" => header } }
+  end
+end

--- a/spec/crowbar/client/request/services/disable_restart_spec.rb
+++ b/spec/crowbar/client/request/services/disable_restart_spec.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+header = "application/vnd.crowbar.v2.0+json"
+
+describe "Crowbar::Client::Request::Services::SetRestartFlag" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Services::SetRestartFlag.new(
+        attrs
+      )
+    end
+
+    let!(:attrs) { { cookbook: "test", disallow_restart: "false" } }
+    let!(:params) { { cookbook: "test", disallow_restart: "false" } }
+    let!(:method) { :post }
+    let!(:url) { "api/restart_management/configuration" }
+    let!(:headers) { { "Accept" => header, "Content-Type" => header } }
+  end
+end

--- a/spec/crowbar/client/request/services/list_restarts_spec.rb
+++ b/spec/crowbar/client/request/services/list_restarts_spec.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Services::ListServiceRestarts" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Services::ListServiceRestarts.new(
+        *attrs
+      )
+    end
+
+    let!(:attrs) do
+      {}
+    end
+
+    let!(:params) do
+      {}
+    end
+
+    let!(:method) do
+      :get
+    end
+
+    let!(:url) do
+      "api/restart_management/restarts"
+    end
+
+    let!(:headers) do
+      {
+        "Accept" => "application/vnd.crowbar.v2.0+json",
+        "Content-Type" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end

--- a/spec/crowbar/client/request/services/restart_flags_spec.rb
+++ b/spec/crowbar/client/request/services/restart_flags_spec.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Services::ListRestartFlags" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Services::ListRestartFlags.new(
+        *attrs
+      )
+    end
+
+    let!(:attrs) do
+      {}
+    end
+
+    let!(:params) do
+      {}
+    end
+
+    let!(:method) do
+      :get
+    end
+
+    let!(:url) do
+      "api/restart_management/configuration"
+    end
+
+    let!(:headers) do
+      {
+        "Accept" => "application/vnd.crowbar.v2.0+json",
+        "Content-Type" => "application/vnd.crowbar.v2.0+json"
+      }
+    end
+  end
+end


### PR DESCRIPTION
Adds the service command and several subcommands to cover the new endpoints provided by https://github.com/crowbar/crowbar-core/pull/1307

The subcommands are as follows:
 - list_restarts: List services that require a restart
 - clear_restart NODE SERVICE: Clear the restart flag for a
service on a node
 - restart_flags: List cookbooks and their restart
status (allowed/disallowed)
 - disable_restart COOKBOOK VALUE: Set the restart
disallowed for a cookbook to true/false