### PR TITLE
rubocop: update obsolete parameter AlignWith for Lint/EndAlignment

### DIFF
--- a/.hound.suse.yml
+++ b/.hound.suse.yml
@@ -12,7 +12,7 @@
 
 Lint/EndAlignment:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#lintendalignment
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Metrics/AbcSize:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#metricsabcsize


### PR DESCRIPTION
rubocop 0.47 obsoletes the AlignWith Lint/EndAlignment
parameter and replaces it with EnforcedStyleAlignWith.