### PR TITLE
travis: Make our travis config trusty ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 sudo: false
+cache: bundler
+dist: trusty
 
 rvm:
-  - 2.1.0
+  - 2.1.9
 
 notifications:
   irc:


### PR DESCRIPTION
Travis started switching to the trusty image which breaks some of our
current setting. This PR fixes them.

cache: this speeds up the hound PR tests
dist: specify the dist to not mix between trusty and precise
rvm: 2.1.0 is not avalible anymore, switch to 2.1.9 which is used in SP3