### PR TITLE
Add filtering of proposal deployment lists

### DIFF
--- a/lib/crowbar/client/command/proposal/edit.rb
+++ b/lib/crowbar/client/command/proposal/edit.rb
@@ -26,6 +26,7 @@ module Crowbar
         #
         class Edit < Base
           include Mixin::Barclamp
+          include Mixin::Proposal
 
           def request
             @request ||= Request::Proposal::Edit.new(
@@ -58,7 +59,7 @@ module Crowbar
 
             case result.code
             when 200
-              result.parsed_response
+              deployment_cleanup result.parsed_response
             when 404
               err "Failed to preload proposal"
             else

--- a/lib/crowbar/client/command/proposal/show.rb
+++ b/lib/crowbar/client/command/proposal/show.rb
@@ -23,6 +23,7 @@ module Crowbar
         #
         class Show < Base
           include Mixin::Barclamp
+          include Mixin::Proposal
 
           include Mixin::Format
           include Mixin::Filter
@@ -45,7 +46,7 @@ module Crowbar
                   headings: ["Key", "Value"],
                   values: Filter::Subset.new(
                     filter: provide_filter,
-                    values: content_from(request)
+                    values: deployment_cleanup(content_from(request))
                   ).result
                 )
 

--- a/lib/crowbar/client/mixin.rb
+++ b/lib/crowbar/client/mixin.rb
@@ -37,6 +37,9 @@ module Crowbar
 
       autoload :SimpleError,
         File.expand_path("../mixin/simple_error", __FILE__)
+
+      autoload :Proposal,
+        File.expand_path("../mixin/proposal", __FILE__)
     end
   end
 end

--- a/lib/crowbar/client/mixin/proposal.rb
+++ b/lib/crowbar/client/mixin/proposal.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "active_support/concern"
+
+module Crowbar
+  module Client
+    module Mixin
+      #
+      # A mixin with proposal related helpers
+      #
+      module Proposal
+        extend ActiveSupport::Concern
+
+        included do
+          protected
+
+          def valid_elements
+            # fetch node list
+            response = Request::Node::List.new.process
+            raise "error fetching node list" unless response.code == 200
+            nodes = response.parsed_response["nodes"].map { |node| node["name"] }
+            # fetch clusters list
+            response = Request::Cluster::List.new.process
+            raise "error fetching cluster list" unless response.code == 200
+            clusters = response.parsed_response.keys
+            nodes + clusters
+          end
+
+          def deployment_cleanup(proposal)
+            filter = valid_elements
+            # filter deployment elements
+            proposal["deployment"][args.barclamp]["elements"].each do |role, elements|
+              elements.select! { |element| filter.include? element }
+            end
+            proposal
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request.rb
+++ b/lib/crowbar/client/request.rb
@@ -32,6 +32,9 @@ module Crowbar
       autoload :Batch,
         File.expand_path("../request/batch", __FILE__)
 
+      autoload :Cluster,
+        File.expand_path("../request/cluster", __FILE__)
+
       autoload :Database,
         File.expand_path("../request/database", __FILE__)
 

--- a/lib/crowbar/client/request/cluster.rb
+++ b/lib/crowbar/client/request/cluster.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      #
+      # Module for the cluster request implementations
+      #
+      module Cluster
+        autoload :List,
+          File.expand_path("../cluster/list", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/cluster/list.rb
+++ b/lib/crowbar/client/request/cluster/list.rb
@@ -1,0 +1,46 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Cluster
+        #
+        # Implementation for the cluster list request
+        #
+        class List < Base
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            "clusters"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/crowbar/client/mixin/proposal_spec.rb
+++ b/spec/crowbar/client/mixin/proposal_spec.rb
@@ -1,0 +1,183 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../spec_helper"
+
+# monkey patch rest-client to make Travis happy
+# see: https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:Update:Products:Cloud7:Update/rubygem-rest-client/add-digest-auth.patch?expand=1
+module RestClient
+  module AbstractResponse
+    def parsed_response
+      JSON.parse(self.body)
+    end
+  end
+end
+
+class ProposalMock
+  include ::Crowbar::Client::Mixin::Proposal
+  # expose protected methods
+  def test_valid_elements
+    valid_elements
+  end
+
+  def test_deployment_cleanup(proposal)
+    deployment_cleanup proposal
+  end
+
+  def test_nodes
+    [
+      "node1",
+      "node2"
+    ]
+  end
+
+  def test_clusters
+    [
+      "cluster1",
+      "cluster2"
+    ]
+  end
+end
+
+describe "Crowbar::Client::Mixin::Proposal" do
+  subject { ProposalMock.new }
+
+  let!(:proposal) do
+    {
+      "deployment" => {
+        "bctest" => {
+          "elements" => {
+            "role1" => [
+              "node1",
+              "oldnode1",
+              "oldnode2",
+              "cluster1",
+              "oldcluster1"
+            ],
+            "role2" => [
+              "node2",
+              "cluster2"
+            ]
+          }
+        }
+      }
+    }
+  end
+
+  before(:each) do
+    allow(subject).to receive_message_chain("args.barclamp") { "bctest" }
+  end
+
+  context "without clusters" do
+    before(:each) do
+      stub_request(:get, "http://crowbar/clusters")
+        .with(
+          headers: {
+            "Accept" => "application/json",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          body: "{}",
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+      stub_request(:get, "http://crowbar/crowbar/machines/1.0")
+        .with(
+          headers: {
+            "Accept" => "application/json",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          body: '{ "nodes": [{"name":"node1"}, {"name":"node2"}] }',
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+    end
+
+    it "valid_elements returns only nodes" do
+      expect(
+        subject.test_valid_elements
+      ).to eq(subject.test_nodes)
+    end
+
+    it "deployment_cleanup removes all clusters and outdated nodes" do
+      clean_proposal = subject.test_deployment_cleanup proposal
+      elements = clean_proposal["deployment"]["bctest"]["elements"]
+      expect(
+        elements["role1"]
+      ).to eq(["node1"])
+      expect(
+        elements["role2"]
+      ).to eq(["node2"])
+    end
+  end
+
+  context "with clusters" do
+    before(:each) do
+      stub_request(:get, "http://crowbar/clusters")
+        .with(
+          headers: {
+            "Accept" => "application/json",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          body: '{"cluster1":{}, "cluster2":{}}',
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+      stub_request(:get, "http://crowbar/crowbar/machines/1.0")
+        .with(
+          headers: {
+            "Accept" => "application/json",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          body: '{"nodes":[{"name":"node1"},{"name":"node2"}]}',
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+    end
+
+    it "valid_elements returns nodes and clusters" do
+      expect(
+        subject.test_valid_elements
+      ).to eq(subject.test_nodes + subject.test_clusters)
+    end
+
+    it "deployment_cleanup removes outdated clusters and nodes" do
+      clean_proposal = subject.test_deployment_cleanup proposal
+      elements = clean_proposal["deployment"]["bctest"]["elements"]
+      expect(
+        elements["role1"]
+      ).to eq(["node1", "cluster1"])
+      expect(
+        elements["role2"]
+      ).to eq(["node2", "cluster2"])
+    end
+  end
+end

--- a/spec/crowbar/client/request/cluster/list_spec.rb
+++ b/spec/crowbar/client/request/cluster/list_spec.rb
@@ -1,0 +1,44 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../../spec_helper"
+
+describe "Crowbar::Client::Request::Cluster::List" do
+  it_behaves_like "a request class", true do
+    subject do
+      ::Crowbar::Client::Request::Cluster::List.new
+    end
+
+    let!(:params) do
+      {}
+    end
+
+    let!(:method) do
+      :get
+    end
+
+    let!(:url) do
+      "clusters"
+    end
+
+    let!(:headers) do
+      {
+        "Content-Type" => "application/json",
+        "Accept" => "application/json"
+      }
+    end
+  end
+end


### PR DESCRIPTION
After some nodes were forgotten, crowbarctl proposal edit and show still included these in deployment list which caused failures when committing proposal. This change makes the behavior consistent with UI which filters out outdated nodes.

NOTE: this requires https://github.com/crowbar/crowbar-core/pull/1338 to provide cluster list endpoint