### PR TITLE
Update rest-client dependency

### DIFF
--- a/crowbar-client.gemspec
+++ b/crowbar-client.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "thor", ">= 0.19.1"
   s.add_runtime_dependency "activesupport", "< 5.0.0", ">= 3.0.0"
 
-  s.add_runtime_dependency "rest-client", "2.0.0"
+  s.add_runtime_dependency "rest-client", "~>2.0"
   s.add_runtime_dependency "net-http-digest_auth", "~> 1.4"
   s.add_runtime_dependency "inifile", ">= 3.0.0"
   s.add_runtime_dependency "terminal-table", ">= 1.4.5"


### PR DESCRIPTION
Instead of hard-requiring exactly version 2.0.0, require a minimum of
2.0.0 with an upper bound of the next major version. This way we can
take advantage of new features and bugfixes in the gem more easily.