### PR TITLE
Escape reserved characters in credentials

### DIFF
--- a/lib/crowbar/client/request/rest.rb
+++ b/lib/crowbar/client/request/rest.rb
@@ -35,8 +35,8 @@ module Crowbar
               "/",
               url
             ].join(""),
-            user: user,
-            password: password,
+            user: URI::DEFAULT_PARSER.escape(user, URI::PATTERN::RESERVED),
+            password: URI::DEFAULT_PARSER.escape(password, URI::PATTERN::RESERVED),
             auth_type: auth_type,
             verify_ssl: verify_ssl,
             timeout: Config.timeout

--- a/spec/crowbar/client/request/rest_spec.rb
+++ b/spec/crowbar/client/request/rest_spec.rb
@@ -19,6 +19,58 @@ require_relative "../../../spec_helper"
 describe "Crowbar::Client::Request::Rest" do
   subject { ::Crowbar::Client::Request::Rest }
 
-  pending
+  context "with default parameters" do
+    before do
+      allow(Crowbar::Client::Config).to receive("server") { "testserver1" }
+      allow(Crowbar::Client::Config).to receive("username") { "testuser1" }
+      allow(Crowbar::Client::Config).to receive("password") { "testpassword1" }
+      allow(Crowbar::Client::Config).to receive("verify_ssl") { true }
+    end
+
+    let!(:instance) do
+      subject.new
+    end
+
+    it "uses root URL from global config" do
+      expect(instance.url).to(eq("testserver1/"))
+    end
+
+    it "uses user from global config" do
+      expect(instance.user).to(eq("testuser1"))
+    end
+
+    it "uses password from global config" do
+      expect(instance.password).to(eq("testpassword1"))
+    end
+
+    it "uses verify_ssl from global config" do
+      expect(instance.options[:verify_ssl]).to(eq(true))
+    end
+
+    it "uses digest auth_type" do
+      expect(instance.options[:auth_type]).to(eq(:digest))
+    end
+  end
+
+  context "with username/password including reserved characters" do
+    let!(:instance) do
+      subject.new(
+        user: "testuser;/?:@&=+$,[]",
+        password: "testpassword;/?:@&=+$,[]"
+      )
+    end
+
+    it "escapes the username" do
+      expect(instance.user).to(
+        eq("testuser%3B%2F%3F%3A%40%26%3D%2B%24%2C%5B%5D")
+      )
+    end
+
+    it "escapes the password" do
+      expect(instance.password).to(
+        eq("testpassword%3B%2F%3F%3A%40%26%3D%2B%24%2C%5B%5D")
+      )
+    end
+  end
 
 end


### PR DESCRIPTION
Some characters are reserved in URIs so when used in usernames or passwords they need to be percent-escaped.