### PR TITLE
Fix for custom user/pwd with 'crowbarctl database'

### DIFF
--- a/lib/crowbar/client/command/database/connect.rb
+++ b/lib/crowbar/client/command/database/connect.rb
@@ -28,8 +28,8 @@ module Crowbar
 
           def args_with_options
             args.easy_merge!(
-              username: options.db_username,
-              password: options.db_password,
+              db_username: options.db_username,
+              db_password: options.db_password,
               database: options.database,
               host: options.host,
               port: options.port

--- a/lib/crowbar/client/command/database/create.rb
+++ b/lib/crowbar/client/command/database/create.rb
@@ -28,8 +28,8 @@ module Crowbar
 
           def args_with_options
             args.easy_merge!(
-              username: options.db_username,
-              password: options.db_password
+              db_username: options.db_username,
+              db_password: options.db_password
             )
           end
 

--- a/lib/crowbar/client/command/database/test.rb
+++ b/lib/crowbar/client/command/database/test.rb
@@ -28,8 +28,8 @@ module Crowbar
 
           def args_with_options
             args.easy_merge!(
-              username: options.db_username,
-              password: options.db_password,
+              db_username: options.db_username,
+              db_password: options.db_password,
               database: options.database,
               host: options.host,
               port: options.port


### PR DESCRIPTION
The code was referencing the wrong variables so the default username
and password were always used. This change corrects the variable
references. Fix confirmed by sniffing the POST data and the proper
values stored in /opt/dell/crowbar_framework/config/database.yml.