### PR TITLE
services: clean restart flags extended

### DIFF
--- a/lib/crowbar/client/app/services.rb
+++ b/lib/crowbar/client/app/services.rb
@@ -35,17 +35,18 @@ module Crowbar
           catch_errors(e)
         end
 
-        desc "clear_restart NODE SERVICE",
+        desc "clear_restart NODE [COOKBOOK [SERVICE]]",
              "Clear the restart flag for a service on a node"
 
         long_desc <<-LONGDESC
-          `clear_restart NODE SERVICE` will clear the 'restart needed' flag
-          for the given SERVICE on the NODE.
+          `clear_restart NODE [COOKBOOK [SERVICE]]` will clear the 'restart needed' flag
+          for the given SERVICE, or all services in a COOKBOOK, or all services on the NODE.
         LONGDESC
-        def clear_restart(node, service)
+        def clear_restart(node, cookbook = nil, service = nil)
           Command::Services::ClearServiceRestart.new(
             *command_params(
               node: node,
+              cookbook: cookbook,
               service: service
             )
           ).execute

--- a/lib/crowbar/client/request/services/clear_restart.rb
+++ b/lib/crowbar/client/request/services/clear_restart.rb
@@ -43,6 +43,7 @@ module Crowbar
           def content
             super.easy_merge!(
               node: attrs.node,
+              cookbook: attrs.cookbook,
               service: attrs.service
             )
           end

--- a/spec/crowbar/client/request/services/clear_restart_spec.rb
+++ b/spec/crowbar/client/request/services/clear_restart_spec.rb
@@ -26,8 +26,8 @@ describe "Crowbar::Client::Request::Services::ClearServiceRestart" do
       )
     end
 
-    let!(:attrs) { { node: "test", service: "test" } }
-    let!(:params) { { node: "test", service: "test" } }
+    let!(:attrs) { { node: "test", cookbook: "test", service: "test" } }
+    let!(:params) { { node: "test", cookbook: "test", service: "test" } }
     let!(:method) { :post }
     let!(:url) { "api/restart_management/restarts" }
     let!(:headers) { { "Accept" => header, "Content-Type" => header } }


### PR DESCRIPTION
In the call clear_restart the parameter SERVICE is optional to allow
the restarting of all services in a node

The commit crowbar/crowbar-core#1509 and crowbar/crowbar-core#1512 are required