### PR TITLE
upgrade: Added support for postpone/resume actions

### DIFF
--- a/lib/crowbar/client/app/upgrade.rb
+++ b/lib/crowbar/client/app/upgrade.rb
@@ -189,8 +189,19 @@ module Crowbar
           catch_errors(e)
         end
 
+        if Config.defaults[:upgrade_versions] == "7-to-8"
+          postpone_resume_short = "|postpone|resume"
+          postpone_resume = <<-RESUME
+            `nodes postpone` will postpone the upgrade of compute nodes.
+            It is possible to use crowbar in this state.
+
+            `nodes resume` will resume the upgrade process.
+            It is possible to go back to upgrading the compute nodes.
+          RESUME
+        end
+
         desc "nodes COMPONENT",
-          "Trigger the node upgrade (all|controllers|NODENAME)"
+          "Trigger the node upgrade (all|controllers|NODENAME#{postpone_resume_short})"
 
         long_desc <<-LONGDESC
           `nodes all` will upgrade all nodes.
@@ -199,6 +210,8 @@ module Crowbar
 
           `nodes NODENAME` will upgrade the node with the NODENAME.
           This only works for compute nodes.
+
+          #{postpone_resume}
         LONGDESC
 
         def nodes(component)

--- a/lib/crowbar/client/command/upgrade/nodes.rb
+++ b/lib/crowbar/client/command/upgrade/nodes.rb
@@ -39,6 +39,10 @@ module Crowbar
                   say "Successfully triggered the upgrade of the nodes. "
                 when "controllers"
                   say "Successfully triggered the upgrade of the controller nodes. "
+                when "postpone"
+                  say "The upgrade of compute nodes was postponed."
+                when "resume"
+                  say "The upgrade process was resumed, compute nodes could be upgraded now."
                 else
                   say "Successfully triggered the upgrade of node #{args.component}. "
                 end


### PR DESCRIPTION
It is now possible to postpone upgrading the compute nodes. 
Requires https://github.com/crowbar/crowbar-core/pull/1574

**Requires** https://github.com/crowbar/crowbar-client/pull/177
