### PR TITLE
crowbarctl: fix 'crowbarctl node show help' wrong info

### DIFF
--- a/lib/crowbar/client/command/node/show.rb
+++ b/lib/crowbar/client/command/node/show.rb
@@ -47,6 +47,8 @@ module Crowbar
 
                 if formatter.empty?
                   err "No result"
+                elsif args.name == "help"
+                  err "Node does not exist"
                 else
                   say formatter.result
                 end


### PR DESCRIPTION
`crowbarctl node show help` should return error because "help" is not a node name. Instead, it currently results in a status code of 200 and outputs unwanted messages. This patch provides an easy workaround to filter the result in this special case and matches the convention used in `crowbarctl node identify help` (outputs "Node does not exist") . The correct way to show help is `crowbarctl node show --help`.

Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1024498