### PR TITLE
upgrade: Fix the "Next step" hint after removing database step

### DIFF
--- a/lib/crowbar/client/command/upgrade/admin.rb
+++ b/lib/crowbar/client/command/upgrade/admin.rb
@@ -36,7 +36,11 @@ module Crowbar
               when 200
                 say "Triggered Crowbar operating system upgrade"
                 say "Wait until the admin server is fully upgraded and rebooted."
-                say "Next step: 'crowbarctl upgrade database [new|connect]'"
+                if Config.defaults[:upgrade_versions] == "6-to-7"
+                  say "Next step: 'crowbarctl upgrade database [new|connect]'"
+                else
+                  say "Next step: 'crowbarctl upgrade repocheck nodes'"
+                end
               else
                 err format_error(
                   request.parsed_response["error"], "admin"


### PR DESCRIPTION
Database step was removed completely, next step after admin upgrade
is repository check for nodes.

**REQUIRES**  https://github.com/crowbar/crowbar-client/pull/177