### PR TITLE
ses: Add ses upload subcommand (SCRD-8432)

### DIFF
--- a/lib/crowbar/client/app.rb
+++ b/lib/crowbar/client/app.rb
@@ -62,6 +62,9 @@ module Crowbar
       autoload :Role,
         File.expand_path("../app/role", __FILE__)
 
+      autoload :Ses,
+        File.expand_path("../app/ses", __FILE__)
+
       autoload :Server,
         File.expand_path("../app/server", __FILE__)
 

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -166,6 +166,13 @@ module Crowbar
         desc "services [COMMANDS]",
           "Services specific commands, call without params for help"
         subcommand "services", Crowbar::Client::App::Services
+
+        desc "ses [COMMANDS]",
+          "SES (Ceph) specific commands, call without params for help"
+        subcommand "ses", Crowbar::Client::App::Ses
+
+        # hide SES command in older versions
+        remove_command :ses unless Config.defaults[:cloud_version].to_i >= 9
       end
     end
   end

--- a/lib/crowbar/client/app/ses.rb
+++ b/lib/crowbar/client/app/ses.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module App
+      #
+      # A Thor based CLI wrapper for SES commands
+      #
+      class Ses < Base
+        desc "upload FILE",
+          "Upload SES configuration file"
+
+        long_desc <<-LONGDESC
+          `upload FILE` will upload yaml file with SES configuration to the
+          server. Data inside this file could be used later for integrating
+          SES cluster with other services.
+        LONGDESC
+
+        #
+        # SES config upload command
+        #
+        # It will upload yaml file with SES configuration to the server.
+        # Data inside this file could be used later for integrating SES
+        # cluster with other services.
+        #
+        # @param file [String] the path to the file
+        #
+        def upload(file)
+          Command::Ses::Upload.new(
+            *command_params(
+              file: file
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command.rb
+++ b/lib/crowbar/client/command.rb
@@ -56,6 +56,9 @@ module Crowbar
       autoload :Role,
         File.expand_path("../command/role", __FILE__)
 
+      autoload :Ses,
+        File.expand_path("../command/ses", __FILE__)
+
       autoload :Server,
         File.expand_path("../command/server", __FILE__)
 

--- a/lib/crowbar/client/command/ses.rb
+++ b/lib/crowbar/client/command/ses.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      #
+      # Module for the SES command implementations
+      #
+      module Ses
+        autoload :Upload,
+          File.expand_path("../ses/upload", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/ses/upload.rb
+++ b/lib/crowbar/client/command/ses/upload.rb
@@ -1,0 +1,60 @@
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Ses
+        #
+        # Implementation for the SES config upload command
+        #
+        class Upload < Base
+          def request
+            args.file =
+              case args.file
+              when "-"
+                stdin.to_io
+              when File
+                args.file
+              else
+                unless File.exist?(args.file)
+                  err "File #{args.file} does not exist."
+                end
+                File.new(
+                  args.file,
+                  File::RDONLY
+                )
+              end
+
+            @request ||= Request::Ses::Upload.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully uploaded SES configuration"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -61,6 +61,7 @@ module Crowbar
           apiversion: default_apiversion,
           experimental: default_experimental,
           upgrade_versions: default_upgrade_versions,
+          cloud_version: default_cloud_version,
           debug: default_debug
         )
       end
@@ -113,6 +114,28 @@ module Crowbar
         return "6-to-7" if os_release["VERSION_ID"] == "12.1"
 
         "7-to-8"
+      end
+
+      #
+      # Define a default cloud version value
+      # It is detected based on OS release for local machine or set by user via ENV variable.
+      #
+      # @return [String] the default cloud version value
+      #
+      def default_cloud_version
+        return ENV["CROWBAR_CLOUD_VERSION"] if ENV["CROWBAR_CLOUD_VERSION"].present?
+
+        os_release = Crowbar::Client::Util::OsRelease.fields
+        case os_release["VERSION_ID"]
+        when "12.1"
+          "6"
+        when "12.2"
+          "7"
+        when "12.3"
+          "8"
+        else
+          "9"
+        end
       end
 
       #

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -109,9 +109,7 @@ module Crowbar
         return "7-to-8" if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
 
         # if upgrade has not been started, check the system version
-        os_release = Crowbar::Client::Util::OsRelease.fields
-
-        return "6-to-7" if os_release["VERSION_ID"] == "12.1"
+        return "6-to-7" if default_cloud_version == "6"
 
         "7-to-8"
       end

--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -108,14 +108,9 @@ module Crowbar
         return "7-to-8" if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
 
         # if upgrade has not been started, check the system version
-        os_release_file = "/etc/os-release"
+        os_release = Crowbar::Client::Util::OsRelease.fields
 
-        if File.exist?(os_release_file)
-          os_release = Hash[
-            File.open(os_release_file).read.scan(/(\S+)\s*=\s*"([^"]+)/)
-          ]
-          return "6-to-7" if os_release["VERSION_ID"] == "12.1"
-        end
+        return "6-to-7" if os_release["VERSION_ID"] == "12.1"
 
         "7-to-8"
       end

--- a/lib/crowbar/client/request.rb
+++ b/lib/crowbar/client/request.rb
@@ -62,6 +62,9 @@ module Crowbar
       autoload :Role,
         File.expand_path("../request/role", __FILE__)
 
+      autoload :Ses,
+        File.expand_path("../request/ses", __FILE__)
+
       autoload :Server,
         File.expand_path("../request/server", __FILE__)
 

--- a/lib/crowbar/client/request/ses.rb
+++ b/lib/crowbar/client/request/ses.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      #
+      # Module for the SES request implementations
+      #
+      module Ses
+        autoload :Upload,
+          File.expand_path("../ses/upload", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/ses/upload.rb
+++ b/lib/crowbar/client/request/ses/upload.rb
@@ -1,0 +1,65 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Ses
+        #
+        # Implementation for the SES config upload request
+        #
+        class Upload < Base
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              sesconfig: {
+                file: attrs.file
+              }
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "ses",
+              "settings",
+              "upload"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/util/apiversion.rb
+++ b/lib/crowbar/client/util/apiversion.rb
@@ -40,15 +40,9 @@ module Crowbar
 
         class << self
           def default
-            os_release_file = "/etc/os-release"
+            os_release = OsRelease.fields
 
-            if File.exist?(os_release_file)
-              os_release = Hash[
-                File.open(os_release_file).read.scan(/(\S+)\s*=\s*"([^"]+)/)
-              ]
-
-              return 1.0 if os_release["VERSION_ID"] == "12.1" && os_release["ID"] == "sles"
-            end
+            return 1.0 if os_release["VERSION_ID"] == "12.1" && os_release["ID"] == "sles"
 
             2.0
           end

--- a/lib/crowbar/client/util/osrelease.rb
+++ b/lib/crowbar/client/util/osrelease.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE Linux GmbH
+# Copyright 2019, SUSE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,21 +16,22 @@
 
 module Crowbar
   module Client
-    #
-    # Module for some utilities used within the client
-    #
     module Util
-      autoload :Editor,
-        File.expand_path("../util/editor", __FILE__)
+      class OsRelease
+        class << self
+          def fields
+            os_release_file = "/etc/os-release"
 
-      autoload :Runner,
-        File.expand_path("../util/runner", __FILE__)
+            if File.exist?(os_release_file)
+              return Hash[
+                File.open(os_release_file).read.scan(/(\S+)\s*=\s*"([^"]+)/)
+              ]
+            end
 
-      autoload :ApiVersion,
-        File.expand_path("../util/apiversion", __FILE__)
-
-      autoload :OsRelease,
-        File.expand_path("../util/osrelease", __FILE__)
+            {}
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `ses upload` subcommand can be used to upload yaml file with SES configuration to crowbar.

**NOTE** there are couple of changes included in this PR which are not strictly related to SES but rather refactoring and/or pre-requisites for actual SES commands.