### PR TITLE
Correctly parse error messages that we don't handle natively

### DIFF
--- a/lib/crowbar/client/command/base.rb
+++ b/lib/crowbar/client/command/base.rb
@@ -58,6 +58,15 @@ module Crowbar
         end
 
         def err(message)
+          if message.is_a?(RestClient::Response)
+            begin
+              json = JSON.parse(message.to_s)
+              message = json.fetch("error", message)
+            rescue JSON::ParserError
+              # too bad, this is not what we expected, we'll print the ugly string
+              nil
+            end
+          end
           raise SimpleCatchableError, message
         end
       end


### PR DESCRIPTION
For instance, when trying to allocate a node that is already allocated:

$ crowbarctl node allocate $node
{"error":"Node already allocated"}

It's because the JSON is actually in a RestClient::Response object. So
handle that case correctly.