### PR TITLE
Add support for the restricted APIs

### DIFF
--- a/lib/crowbar/client/app.rb
+++ b/lib/crowbar/client/app.rb
@@ -59,6 +59,9 @@ module Crowbar
       autoload :Repository,
         File.expand_path("../app/repository", __FILE__)
 
+      autoload :Restricted,
+        File.expand_path("../app/restricted", __FILE__)
+
       autoload :Role,
         File.expand_path("../app/role", __FILE__)
 

--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -171,8 +171,14 @@ module Crowbar
           "SES (Ceph) specific commands, call without params for help"
         subcommand "ses", Crowbar::Client::App::Ses
 
+        desc "restricted [COMMANDS]",
+          "Commands specifc to restricted clients, call without params for help"
+        subcommand "restricted", Crowbar::Client::App::Restricted
+
         # hide SES command in older versions
         remove_command :ses unless Config.defaults[:cloud_version].to_i >= 9
+        # hide Restricted command in older versions
+        remove_command :restricted unless Config.defaults[:cloud_version].to_i >= 9
       end
     end
   end

--- a/lib/crowbar/client/app/restricted.rb
+++ b/lib/crowbar/client/app/restricted.rb
@@ -1,0 +1,136 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module App
+      #
+      # A Thor based CLI wrapper for restricted commands
+      #
+      class Restricted < Base
+        desc "allocate NAME_OR_ALIAS",
+          "Allocate the specified node"
+
+        long_desc <<-LONGDESC
+          `allocate NAME_OR_ALIAS` will try to allocate the specified
+          node.
+        LONGDESC
+
+        def allocate(name)
+          Command::Restricted::Allocate.new(
+            *command_params(
+              name: name
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "ping",
+          "Ping the administration server"
+
+        long_desc <<-LONGDESC
+          `ping` will check that the administration server is up.
+        LONGDESC
+
+        def ping
+          Command::Restricted::Ping.new(
+            *command_params
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "show NAME_OR_ALIAS",
+          "Show restricted data for a specific node"
+
+        long_desc <<-LONGDESC
+          `show NAME_OR_ALIAS` will try to fetch the restricted data
+          for the specified node. If you just want to see a specific
+          subset of the restricted data you can provide the --filter
+          option separated by a dot for every element.
+
+          With --format <format> option you can choose an output format
+          with the available options table, json or plain. You can also
+          use the shortcut options --table, --json or --plain.
+
+          With --filter <filter> option you can limit the result of
+          printed out elements. You can use any substring that is part
+          of the found elements.
+        LONGDESC
+
+        method_option :format,
+          type: :string,
+          default: "table",
+          banner: "<format>",
+          desc: "Format of the output, valid formats are table, json or plain"
+
+        method_option :table,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as table, a shortcut for --format table option"
+
+        method_option :json,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as json, a shortcut for --format json option"
+
+        method_option :plain,
+          type: :boolean,
+          default: false,
+          aliases: [],
+          desc: "Format output as plain text, a shortcut for --format plain option"
+
+        method_option :filter,
+          type: :string,
+          default: nil,
+          banner: "<filter>",
+          desc: "Filter by criteria, display only data that contains filter"
+
+        def show(name)
+          Command::Restricted::Show.new(
+            *command_params(
+              name: name
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+
+        desc "transition NAME_OR_ALIAS STATE",
+          "Transition a node to a specific state"
+
+        long_desc <<-LONGDESC
+          `transition NAME_OR_ALIAS STATE` will try to transition the
+          specified node into a specified state.
+        LONGDESC
+
+        def transition(name, state)
+          Command::Restricted::Transition.new(
+            *command_params(
+              name: name,
+              state: state
+            )
+          ).execute
+        rescue => e
+          catch_errors(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command.rb
+++ b/lib/crowbar/client/command.rb
@@ -53,6 +53,9 @@ module Crowbar
       autoload :Repository,
         File.expand_path("../command/repository", __FILE__)
 
+      autoload :Restricted,
+        File.expand_path("../command/restricted", __FILE__)
+
       autoload :Role,
         File.expand_path("../command/role", __FILE__)
 

--- a/lib/crowbar/client/command/restricted.rb
+++ b/lib/crowbar/client/command/restricted.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      #
+      # Module for the Restricted command implementations
+      #
+      module Restricted
+        autoload :Allocate,
+          File.expand_path("../restricted/allocate", __FILE__)
+
+        autoload :Ping,
+          File.expand_path("../restricted/ping", __FILE__)
+
+        autoload :Show,
+          File.expand_path("../restricted/show", __FILE__)
+
+        autoload :Transition,
+          File.expand_path("../restricted/transition", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/restricted/allocate.rb
+++ b/lib/crowbar/client/command/restricted/allocate.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Command
+      module Restricted
+        #
+        # Implementation for the restricted allocate command
+        #
+        class Allocate < Base
+          def request
+            @request ||= Request::Restricted::Allocate.new(
+              args.easy_merge(
+                action: :allocate
+              )
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully triggered allocate for #{args.name}"
+              when 404
+                err "Node does not exist"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/restricted/ping.rb
+++ b/lib/crowbar/client/command/restricted/ping.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Restricted
+        #
+        # Implementation for the restricted ping command
+        #
+        class Ping < Base
+          def request
+            @request ||= Request::Restricted::Ping.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully pinged the administration server"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/restricted/show.rb
+++ b/lib/crowbar/client/command/restricted/show.rb
@@ -1,0 +1,72 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Restricted
+        #
+        # Implementation for the restricted show command
+        #
+        class Show < Base
+          include Mixin::Format
+          include Mixin::Filter
+
+          def request
+            @request ||= Request::Restricted::Show.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                formatter = Formatter::Nested.new(
+                  format: provide_format,
+                  path: provide_filter,
+                  headings: ["Key", "Value"],
+                  values: Filter::Subset.new(
+                    filter: provide_filter,
+                    values: content_from(request)
+                  ).result
+                )
+
+                if formatter.empty?
+                  err "No result"
+                elsif args.name == "help"
+                  err "Node does not exist"
+                else
+                  say formatter.result
+                end
+              when 404
+                err "Node does not exist"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+
+          protected
+
+          def content_from(request)
+            request.parsed_response
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/command/restricted/transition.rb
+++ b/lib/crowbar/client/command/restricted/transition.rb
@@ -1,0 +1,47 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Command
+      module Restricted
+        #
+        # Implementation for the restricted transition command
+        #
+        class Transition < Base
+          def request
+            @request ||= Request::Restricted::Transition.new(
+              args
+            )
+          end
+
+          def execute
+            request.process do |request|
+              case request.code
+              when 200
+                say "Successfully transitioned to #{args.state}"
+              when 404
+                err "Node does not exist"
+              else
+                err request.parsed_response["error"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request.rb
+++ b/lib/crowbar/client/request.rb
@@ -59,6 +59,9 @@ module Crowbar
       autoload :Rest,
         File.expand_path("../request/rest", __FILE__)
 
+      autoload :Restricted,
+        File.expand_path("../request/restricted", __FILE__)
+
       autoload :Role,
         File.expand_path("../request/role", __FILE__)
 

--- a/lib/crowbar/client/request/restricted.rb
+++ b/lib/crowbar/client/request/restricted.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      #
+      # Module for the Restricted request implementations
+      #
+      module Restricted
+        autoload :Allocate,
+          File.expand_path("../restricted/allocate", __FILE__)
+
+        autoload :Ping,
+          File.expand_path("../restricted/ping", __FILE__)
+
+        autoload :Show,
+          File.expand_path("../restricted/show", __FILE__)
+
+        autoload :Transition,
+          File.expand_path("../restricted/transition", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/restricted/allocate.rb
+++ b/lib/crowbar/client/request/restricted/allocate.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Restricted
+        #
+        # Implementation for the restricted allocate request
+        #
+        class Allocate < Base
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "restricted",
+              "allocate",
+              attrs.name
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/restricted/ping.rb
+++ b/lib/crowbar/client/request/restricted/ping.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Restricted
+        #
+        # Implementation for the restricted ping request
+        #
+        class Ping < Base
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "restricted",
+              "ping"
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/restricted/show.rb
+++ b/lib/crowbar/client/request/restricted/show.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Client
+    module Request
+      module Restricted
+        #
+        # Implementation for the restricted show request
+        #
+        class Show < Base
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :get
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "restricted",
+              "show",
+              attrs.name
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crowbar/client/request/restricted/transition.rb
+++ b/lib/crowbar/client/request/restricted/transition.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "easy_diff"
+
+module Crowbar
+  module Client
+    module Request
+      module Restricted
+        #
+        # Implementation for the restricted transition request
+        #
+        class Transition < Base
+          #
+          # Override the request content
+          #
+          # @return [Hash] the content for the request
+          #
+          def content
+            super.easy_merge!(
+              state: attrs.state
+            )
+          end
+
+          #
+          # HTTP method that gets used by the request
+          #
+          # @return [Symbol] the method for the request
+          #
+          def method
+            :post
+          end
+
+          #
+          # Path to the API endpoint for the request
+          #
+          # @return [String] path to the API endpoint
+          #
+          def url
+            [
+              "restricted",
+              "transition",
+              attrs.name
+            ].join("/")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The restricted APIs are the ones that can be used for clients with
restricted access, to do operations from insecure nodes:
crowbar_register, crowbar_join, discovery, provisioning.

This goes with https://github.com/crowbar/crowbar-core/pull/1817