### PR TITLE
Add --raw to "proposal show" & "proposal edit"

### DIFF
--- a/lib/crowbar/client/app/proposal.rb
+++ b/lib/crowbar/client/app/proposal.rb
@@ -98,6 +98,10 @@ module Crowbar
           With --filter <filter> option you can limit the result of
           printed out elements. You can use any substring that is part
           of the found elements.
+
+          With --raw option you can ensure that the program will not
+          automatically alter the proposal (to remove non-existing
+          nodes, for instance).
         LONGDESC
 
         method_option :format,
@@ -129,6 +133,12 @@ module Crowbar
           default: nil,
           banner: "<filter>",
           desc: "Filter by criteria, display only data that contains filter"
+
+        method_option :raw,
+          type: :boolean,
+          default: false,
+          aliases: ["-r"],
+          desc: "Do not automatically edit the content of the proposal data"
 
         def show(barclamp, proposal)
           Command::Proposal::Show.new(
@@ -221,6 +231,10 @@ module Crowbar
 
           With --merge option you can deep merge the provided data with
           the preloaded proposal.
+
+          With --raw option you can ensure that the program will not
+          automatically alter the proposal (to remove non-existing
+          nodes, for instance).
         LONGDESC
 
         method_option :data,
@@ -240,6 +254,12 @@ module Crowbar
           default: false,
           aliases: ["-m"],
           desc: "Merge input loaded from server with proposal data"
+
+        method_option :raw,
+          type: :boolean,
+          default: false,
+          aliases: ["-r"],
+          desc: "Do not automatically edit the content of the proposal data"
 
         def edit(barclamp, proposal)
           Command::Proposal::Edit.new(

--- a/lib/crowbar/client/command/proposal/edit.rb
+++ b/lib/crowbar/client/command/proposal/edit.rb
@@ -59,7 +59,11 @@ module Crowbar
 
             case result.code
             when 200
-              deployment_cleanup result.parsed_response
+              if options[:raw]
+                result.parsed_response
+              else
+                deployment_cleanup result.parsed_response
+              end
             when 404
               err "Failed to preload proposal"
             else

--- a/lib/crowbar/client/command/proposal/show.rb
+++ b/lib/crowbar/client/command/proposal/show.rb
@@ -40,13 +40,19 @@ module Crowbar
             request.process do |request|
               case request.code
               when 200
+                content = if options[:raw]
+                  content_from(request)
+                else
+                  deployment_cleanup(content_from(request))
+                end
+
                 formatter = Formatter::Nested.new(
                   format: provide_format,
                   path: provide_filter,
                   headings: ["Key", "Value"],
                   values: Filter::Subset.new(
                     filter: provide_filter,
-                    values: deployment_cleanup(content_from(request))
+                    values: content
                   ).result
                 )
 


### PR DESCRIPTION
This option allows to not automatically cleanup the proposal data, which
we usually do to remove non-existing nodes, for instance.

This is useful to see what is really in the proposal.