### PR TITLE
upgrade: Fix repocheck table output (SOC-10718)

### DIFF
--- a/lib/crowbar/client/command/upgrade/repocheck.rb
+++ b/lib/crowbar/client/command/upgrade/repocheck.rb
@@ -50,6 +50,8 @@ module Crowbar
                         bad_repos.each do |bad_repo|
                           hint = "Some repopositories are not available. " \
                             "Fix the problem and call the step again."
+                          repos[bad_repo] = { repo: bad_repo, status: [], type: type } \
+                            unless repos.key? bad_repo
                           repos[bad_repo][:status] << "#{error} (#{arch})"
                         end
                       end


### PR DESCRIPTION
If some repo is only listed under "errors", the table formatter was
failing.

Example API response:
```
{
  "os": {
    "available": true,
    "repos": [
      "SLES12-SP3-Pool",
      "SLES12-SP3-Updates"
    ],
    "errors": {
    }
  },
  "openstack": {
    "available": false,
    "repos": [
      "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
      "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
    ],
    "errors": {
      "missing": {
        "x86_64": [
          "Cloud"
        ]
      },
      "inactive": {
        "x86_64": [
          "Cloud"
        ]
      }
    }
  }
}