### PR TITLE
Increase the default timeout (SOC-10513)

### DIFF
--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -196,7 +196,7 @@ module Crowbar
         if ENV["CROWBAR_TIMEOUT"].present?
           ENV["CROWBAR_TIMEOUT"].to_i
         else
-          3600
+          4500
         end
       end
 


### PR DESCRIPTION
Depending on the environment a single chef run can take more than 15
minutes, consequently applying some barclamps (e.g. ceilometer) which
has 4 roles (meaning that chef will run 4 times) on those environments
are failing due to a timeout.