### PR TITLE
Revert "Increase the default timeout (SOC-10513)"

### DIFF
--- a/lib/crowbar/client/config.rb
+++ b/lib/crowbar/client/config.rb
@@ -196,7 +196,7 @@ module Crowbar
         if ENV["CROWBAR_TIMEOUT"].present?
           ENV["CROWBAR_TIMEOUT"].to_i
         else
-          4500
+          3600
         end
       end
 


### PR DESCRIPTION
Turns out that changing the product timeouts are really dangerous and
it is recommended to do only on a major product version change (see: https://github.com/crowbar/crowbar-client/pull/194#issuecomment-575243669).

This reverts commit d6e0f08db5bfb026db941ff080899551b4da6366.