### PR TITLE
ses: Enable SES commands in Cloud8 (SOC-11122)

### DIFF
--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -176,7 +176,7 @@ module Crowbar
         subcommand "restricted", Crowbar::Client::App::Restricted
 
         # hide SES command in older versions
-        remove_command :ses unless Config.defaults[:cloud_version].to_i >= 9
+        remove_command :ses unless Config.defaults[:cloud_version].to_i >= 8
         # hide Restricted command in older versions
         remove_command :restricted unless Config.defaults[:cloud_version].to_i >= 9
       end


### PR DESCRIPTION
SES commands were added in 6a3465fff34665652383b731b478d1f7a3f77fe0 but were disabled for cloud versions < 9.