### PR TITLE
Enable restricted commands for Cloud 7 (bsc#1117080)

### DIFF
--- a/lib/crowbar/client/app/entry.rb
+++ b/lib/crowbar/client/app/entry.rb
@@ -178,7 +178,7 @@ module Crowbar
         # hide SES command in older versions
         remove_command :ses unless Config.defaults[:cloud_version].to_i >= 8
         # hide Restricted command in older versions
-        remove_command :restricted unless Config.defaults[:cloud_version].to_i >= 8
+        remove_command :restricted unless Config.defaults[:cloud_version].to_i >= 7
       end
     end
   end


### PR DESCRIPTION
This is needed to backport the crowbar-core side changes from
Cloud 8.