### PR TITLE
Fix link to 3.9.3 tag in change log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.9.3](https://github.com/crowbar/crowbar-client/releases/tag/v3.9.2) - 2020-09-02
+## [3.9.3](https://github.com/crowbar/crowbar-client/releases/tag/v3.9.3) - 2020-09-02
 
 * ENHANCEMENT
   * Enable restricted commands for Cloud 7 (bsc#1117080)


### PR DESCRIPTION
The tag link in the change log pointed to the 3.9.2 release tag. This pull request corrects it.